### PR TITLE
Fix llama_flash_attn_func which uses llama style backward for numerical stability of dq

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ torchrun --nproc_per_node 8 test/test_zigzag_ring_flash_attn_func.py
 torchrun --nproc_per_node 8 test/test_zigzag_ring_flash_attn_varlen_func.py
 torchrun --nproc_per_node 8 test/test_stripe_flash_attn_func.py
 torchrun --nproc_per_node 4 test/test_llama_flash_attn.py
+torchrun --nproc_per_node 4 test/test_llama_fwd_ring_bwd_flash_attn.py
 ```
 
 ### Benchmark

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ torchrun --nproc_per_node 8 test/test_ring_flash_attn_varlen_func.py
 torchrun --nproc_per_node 8 test/test_zigzag_ring_flash_attn_func.py
 torchrun --nproc_per_node 8 test/test_zigzag_ring_flash_attn_varlen_func.py
 torchrun --nproc_per_node 8 test/test_stripe_flash_attn_func.py
+torchrun --nproc_per_node 4 test/test_llama_flash_attn.py
 ```
 
 ### Benchmark

--- a/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
+++ b/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
@@ -317,6 +317,7 @@ def llama_flash_attn_backward(
 
     for i in range(0, nheads_k, heads_k_stride):
         # Must zero out because for Causal, we don't write to the entire sequence length
+        # i.e., use buffer up to (rank+1) instead of full sequence
         dkv_buffer.zero_()
 
         q_slice = slice(

--- a/ring_flash_attn/ring_flash_attn.py
+++ b/ring_flash_attn/ring_flash_attn.py
@@ -96,6 +96,7 @@ def ring_flash_attn_backward(
     softcap=0.0,
     alibi_slopes=None,
     deterministic=False,
+    time_event=None,  # Sync GPU,CPU to lower vRAM allocation; no sync by default
 ):
     kv_comm = RingComm(process_group)
     d_kv_comm = RingComm(process_group)

--- a/ring_flash_attn/ring_flash_attn.py
+++ b/ring_flash_attn/ring_flash_attn.py
@@ -96,7 +96,6 @@ def ring_flash_attn_backward(
     softcap=0.0,
     alibi_slopes=None,
     deterministic=False,
-    time_event=None,  # Sync GPU,CPU to lower vRAM allocation; no sync by default
 ):
     kv_comm = RingComm(process_group)
     d_kv_comm = RingComm(process_group)
@@ -113,8 +112,6 @@ def ring_flash_attn_backward(
     for step in range(kv_comm.world_size):
         if step + 1 != kv_comm.world_size:
             next_k, next_v = kv_comm.send_recv_kv(k, v)
-        elif time_event is not None:
-            time_event.record()
 
         if step <= kv_comm.rank or not causal:
             bwd_causal = causal and step == 0

--- a/ring_flash_attn/ring_flash_attn.py
+++ b/ring_flash_attn/ring_flash_attn.py
@@ -112,6 +112,8 @@ def ring_flash_attn_backward(
     for step in range(kv_comm.world_size):
         if step + 1 != kv_comm.world_size:
             next_k, next_v = kv_comm.send_recv_kv(k, v)
+        elif time_event is not None:
+            time_event.record()
 
         if step <= kv_comm.rank or not causal:
             bwd_causal = causal and step == 0

--- a/test/test_cond_llama_fwd_ring_bwd_flash_attn.py
+++ b/test/test_cond_llama_fwd_ring_bwd_flash_attn.py
@@ -117,5 +117,5 @@ if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] == "compile":
         torch._dynamo.config.capture_scalar_outputs = True
         # FIX 1 (continued): Compile the actual function used
-        llama_fwd_ring_bwd_flash_attn_func = torch.compile(llama_fwd_ring_bwd_flash_attn_func)
+        cond_llama_fwd_ring_bwd_flash_attn_func = torch.compile(cond_llama_fwd_ring_bwd_flash_attn_func)
     main()

--- a/test/test_cond_llama_fwd_ring_bwd_flash_attn.py
+++ b/test/test_cond_llama_fwd_ring_bwd_flash_attn.py
@@ -1,0 +1,121 @@
+import sys
+import torch
+import torch.distributed as dist
+from flash_attn import flash_attn_qkvpacked_func
+from ring_flash_attn.llama_fwd_ring_bwd_flash_attn import cond_llama_fwd_ring_bwd_flash_attn_func
+from utils import log, set_seed
+
+def main():
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    set_seed(rank)
+    world_size = dist.get_world_size()
+    dtype = torch.bfloat16
+    device = torch.device(f"cuda:{rank}")
+
+    batch_size = 8
+    seqlen = 3816
+    nheads = 6
+    d = 128
+    dropout_p = 0
+    causal = False
+    deterministic = False
+
+    assert seqlen % world_size == 0
+    assert d % 8 == 0
+
+    # --- Setup Inputs ---
+    qkv = torch.randn(
+        batch_size, seqlen, 3, nheads, d, device=device, dtype=dtype, requires_grad=True
+    )
+    dist.broadcast(qkv, src=0)
+
+    dout = torch.randn(batch_size, seqlen, nheads, d, device=device, dtype=dtype)
+    dist.broadcast(dout, src=0)
+
+    # Create local shards (detached from global graph for fresh start)
+    local_qkv = qkv.chunk(world_size, dim=0)[rank].detach().clone()
+    local_qkv.requires_grad = True
+    local_dout = dout.chunk(world_size, dim=0)[rank].detach().clone()
+
+    dist.barrier()
+
+    # --- Baseline: Standard Flash Attention ---
+    if rank == 0:
+        print("#" * 30)
+        print("# forward:")
+        print("#" * 30)
+
+    out, lse, _ = flash_attn_qkvpacked_func(
+        qkv,
+        dropout_p=dropout_p,
+        causal=causal,
+        window_size=(-1, -1),
+        alibi_slopes=None,
+        deterministic=deterministic,
+        return_attn_probs=True,
+    )
+
+    # local_out = out.chunk(world_size, dim=1)[rank]
+    # local_lse = lse.chunk(world_size, dim=-1)[rank]
+    local_out = out.chunk(world_size, dim=0)[rank]
+    local_lse = lse.chunk(world_size, dim=0)[rank]
+
+    # --- Test Subject: Ring Attention ---
+    # FIX 1: Correct variable name for compilation hook
+    fn = cond_llama_fwd_ring_bwd_flash_attn_func
+    
+    # FIX 2: Removed .squeeze(2). Indexing [:,:,0] results in (B, S, H, D)
+    ring_out, ring_lse, _ = fn(
+        local_qkv[:,:,0], 
+        local_qkv[:,:,1], 
+        local_qkv[:,:,2], 
+        heads_k_stride=1,
+        bwd_event_sync=False,
+        dropout_p=dropout_p,
+        causal=causal,
+        window_size=(-1, -1),
+        alibi_slopes=None,
+        deterministic=deterministic,
+        return_attn_probs=True,
+        # group=dist.group.WORLD,
+        group=None,
+    )
+
+    log("out", out, rank0_only=True)
+    log("lse", lse, rank0_only=True)
+    log("out diff", local_out - ring_out)
+    # Note: LSE might require adjustment depending on implementation (scaling factors)
+    log("lse diff", local_lse - ring_lse) 
+
+    dist.barrier()
+    if rank == 0:
+        print("#" * 30)
+        print("# backward:")
+        print("#" * 30)
+
+    # --- Backward Baseline ---
+    out.backward(dout)
+    dqkv = qkv.grad
+    local_dqkv = dqkv.chunk(world_size, dim=0)[rank]
+
+    # --- Backward Ring ---
+    ring_out.backward(local_dout)
+    ring_dqkv = local_qkv.grad
+
+    log("local_dqkv", local_dqkv)
+    
+    # FIX 3: Correct indexing to compare Q, K, and V specifically
+    # Shape is (Batch, Seq, 3, Heads, Dim). We slice dim 2.
+    log("dq diff", local_dqkv[:, :, 0] - ring_dqkv[:, :, 0])
+    log("dk diff", local_dqkv[:, :, 1] - ring_dqkv[:, :, 1])
+    log("dv diff", local_dqkv[:, :, 2] - ring_dqkv[:, :, 2])
+
+    dist.destroy_process_group()
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "compile":
+        torch._dynamo.config.capture_scalar_outputs = True
+        # FIX 1 (continued): Compile the actual function used
+        llama_fwd_ring_bwd_flash_attn_func = torch.compile(llama_fwd_ring_bwd_flash_attn_func)
+    main()

--- a/test/test_llama_flash_attn.py
+++ b/test/test_llama_flash_attn.py
@@ -13,9 +13,9 @@ def main():
     dtype = torch.bfloat16
     device = torch.device(f"cuda:{rank}")
 
-    batch_size = 1
+    batch_size = 8
     seqlen = 3816
-    nheads = 5
+    nheads = 6
     d = 128
     dropout_p = 0
     causal = False
@@ -68,8 +68,8 @@ def main():
         local_qkv[:,:,0], 
         local_qkv[:,:,1], 
         local_qkv[:,:,2], 
-        heads_k_stride=1,
-        bwd_event_sync=False,
+        heads_k_stride=2,
+        bwd_event_sync=True,
         dropout_p=dropout_p,
         causal=causal,
         window_size=(-1, -1),

--- a/test/test_llama_flash_attn.py
+++ b/test/test_llama_flash_attn.py
@@ -2,7 +2,7 @@ import sys
 import torch
 import torch.distributed as dist
 from flash_attn import flash_attn_qkvpacked_func
-from ring_flash_attn.llama_fwd_ring_bwd_flash_attn import llama_fwd_ring_bwd_flash_attn_func
+from ring_flash_attn.llama_fwd_ring_bwd_flash_attn import llama_flash_attn_func
 from utils import log, set_seed
 
 def main():
@@ -61,7 +61,7 @@ def main():
 
     # --- Test Subject: Ring Attention ---
     # FIX 1: Correct variable name for compilation hook
-    fn = llama_fwd_ring_bwd_flash_attn_func
+    fn = llama_flash_attn_func 
     
     # FIX 2: Removed .squeeze(2). Indexing [:,:,0] results in (B, S, H, D)
     ring_out, ring_lse, _ = fn(

--- a/test/test_llama_fwd_ring_bwd_flash_attn.py
+++ b/test/test_llama_fwd_ring_bwd_flash_attn.py
@@ -13,9 +13,9 @@ def main():
     dtype = torch.bfloat16
     device = torch.device(f"cuda:{rank}")
 
-    batch_size = 1
-    seqlen = 8196 #3816
-    nheads = 5
+    batch_size = 8
+    seqlen = 3816
+    nheads = 6
     d = 128
     dropout_p = 0
     causal = False

--- a/test/test_llama_fwd_ring_bwd_flash_attn.py
+++ b/test/test_llama_fwd_ring_bwd_flash_attn.py
@@ -14,7 +14,7 @@ def main():
     device = torch.device(f"cuda:{rank}")
 
     batch_size = 1
-    seqlen = 3816
+    seqlen = 8196 #3816
     nheads = 5
     d = 128
     dropout_p = 0

--- a/test/test_llama_fwd_ring_bwd_flash_attn.py
+++ b/test/test_llama_fwd_ring_bwd_flash_attn.py
@@ -113,5 +113,5 @@ if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] == "compile":
         torch._dynamo.config.capture_scalar_outputs = True
         # FIX 1 (continued): Compile the actual function used
-        llama_flash_attn_func = torch.compile(llama_flash_attn_func)
+        llama_fwd_ring_bwd_flash_attn_func = torch.compile(llama_fwd_ring_bwd_flash_attn_func)
     main()


### PR DESCRIPTION
This pull request implements the backward pass for Llama-style ring Flash Attention, refactors and improves the function signatures and buffer management, and adds a new distributed test for the Llama Flash Attention implementation. The changes enable end-to-end forward and backward testing for distributed attention, fix several interface and tensor handling issues, and improve documentation and maintainability.

### Llama-style ring Flash Attention implementation and refactor

* Implemented the full backward pass for `llama_flash_attn_backward`, replacing the previous `NotImplementedError` with a working distributed algorithm, including buffer allocation, communication, and correct gradient handling for both causal and non-causal cases. Improved documentation for arguments and return values. [[1]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2L239-R271) [[2]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R280-R301) [[3]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R317) [[4]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2L299) [[5]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2L313-R361) [[6]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2L338-R412)
* Refactored function signatures for `LlamaFlashAttnFunc`, `llama_flash_attn_func`, and related functions to use explicit type annotations, add new arguments (`head_first_stride`, `bwd_event_sync`), and improve clarity and compatibility with PyTorch compilation. [[1]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2L489-R636) [[2]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2L562-R656) [[3]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2L636-R750) [[4]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R759)

### Distributed testing and validation

* Added a new distributed test script `test/test_llama_flash_attn.py` to compare the ring-based implementation against standard Flash Attention, including both forward and backward passes, with detailed logging and correctness checks for gradients.
* Updated the README to include instructions for running the new test.

### Test script improvements and bug fixes

* Improved `test_llama_fwd_ring_bwd_flash_attn.py` by increasing sequence length, clarifying input setup, fixing tensor indexing for correct shape, and improving logging and comparison of outputs and gradients. [[1]](diffhunk://#diff-62f254282c814f0a082c6632fabcd8a9aeb21b4d521dd3dad9b36f656ac59c3dL8) [[2]](diffhunk://#diff-62f254282c814f0a082c6632fabcd8a9aeb21b4d521dd3dad9b36f656ac59c3dL18-R17) [[3]](diffhunk://#diff-62f254282c814f0a082c6632fabcd8a9aeb21b4d521dd3dad9b36f656ac59c3dR27) [[4]](diffhunk://#diff-62f254282c814f0a082c6632fabcd8a9aeb21b4d521dd3dad9b36f656ac59c3dR36-R43) [[5]](diffhunk://#diff-62f254282c814f0a082c6632fabcd8a9aeb21b4d521dd3dad9b36f656ac59c3dR62-R70) [[6]](diffhunk://#diff-62f254282c814f0a082c6632fabcd8a9aeb21b4d521dd3dad9b36f656ac59c3dR84)