### PR TITLE
reapply cond event sync

### DIFF
--- a/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
+++ b/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
@@ -930,6 +930,7 @@ class ConditionalLlamaFlashAttnFunc(torch.autograd.Function):
             else:
                 assert len(outputs) == 4
                 out, softmax_lse, _, _ = outputs
+            ctx.bwd_event_sync = False
         else:
             # out shape (batch, seq, heads, head_dim)
             # softmax_lse shape (batch, heads, seq)
@@ -947,6 +948,7 @@ class ConditionalLlamaFlashAttnFunc(torch.autograd.Function):
                 alibi_slopes=alibi_slopes,
                 deterministic=False,
             )
+            ctx.bwd_event_sync = bwd_event_sync
         ctx.save_for_backward(q, k, v, out, softmax_lse)
         ctx.dropout_p = dropout_p
         ctx.softmax_scale = softmax_scale
@@ -955,7 +957,6 @@ class ConditionalLlamaFlashAttnFunc(torch.autograd.Function):
         ctx.alibi_slopes = alibi_slopes
         ctx.deterministic = deterministic
         ctx.group = group
-        ctx.bwd_event_sync = bwd_event_sync
         ctx.heads_k_stride = heads_k_stride
         return out if not return_softmax else (out, softmax_lse, None)
 
@@ -1095,6 +1096,7 @@ class ConditionalLlamaRingFlashAttnFunc(torch.autograd.Function):
             else:
                 assert len(outputs) == 4
                 out, softmax_lse, _, _ = outputs
+            ctx.bwd_event_sync = False
         else:
             # out shape (batch, seq, heads, head_dim)
             # softmax_lse shape (batch, heads, seq)
@@ -1112,6 +1114,7 @@ class ConditionalLlamaRingFlashAttnFunc(torch.autograd.Function):
                 alibi_slopes=alibi_slopes,
                 deterministic=False,
             )
+            ctx.bwd_event_sync = bwd_event_sync
         ctx.save_for_backward(q, k, v, out, softmax_lse)
         ctx.dropout_p = dropout_p
         ctx.softmax_scale = softmax_scale
@@ -1120,7 +1123,6 @@ class ConditionalLlamaRingFlashAttnFunc(torch.autograd.Function):
         ctx.alibi_slopes = alibi_slopes
         ctx.deterministic = deterministic
         ctx.group = group
-        ctx.bwd_event_sync = bwd_event_sync
         ctx.heads_k_stride = heads_k_stride
         return out if not return_softmax else (out, softmax_lse, None)
 

--- a/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
+++ b/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
@@ -897,6 +897,7 @@ class ConditionalLlamaFlashAttnFunc(torch.autograd.Function):
             return_softmax (bool): Whether to return the softmax log-sum-exp.
             group (dist.ProcessGroup): The distributed process group.
             bwd_event_sync (bool): If True, syncs a CUDA event in the backward pass to control memory allocation.
+                Only applicable when group is not None.
 
         Returns:
             Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, None]]: The attention output, and optionally the LSE and a None placeholder.
@@ -1063,6 +1064,7 @@ class ConditionalLlamaRingFlashAttnFunc(torch.autograd.Function):
             return_softmax (bool): Whether to return the softmax log-sum-exp.
             group (dist.ProcessGroup): The distributed process group.
             bwd_event_sync (bool): If True, syncs a CUDA event in the backward pass to control memory allocation.
+                Only applicable when group is not None.
 
         Returns:
             Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, None]]: The attention output, and optionally the LSE and a None placeholder.


### PR DESCRIPTION
This pull request refines how the `bwd_event_sync` context variable is set in the `forward` method of `llama_fwd_ring_bwd_flash_attn.py`. The main change is to ensure that `ctx.bwd_event_sync` is only set in specific branches of the logic, improving clarity and correctness in the context handling.

Context variable handling improvements:

* Set `ctx.bwd_event_sync = False` explicitly in the branch where outputs are directly unpacked, ensuring it's only set to `False` in that scenario. [[1]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R933) [[2]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R1099)
* Set `ctx.bwd_event_sync = bwd_event_sync` only in the branch where the variable is relevant, rather than unconditionally at the end of the method. [[1]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R951) [[2]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R1117)
* Removed the unconditional assignment of `ctx.bwd_event_sync = bwd_event_sync` at the end of the method to avoid redundant or incorrect context state. [[1]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2L958) [[2]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2L1123)