### PR TITLE
Opt llamafwd firststride

### DIFF
--- a/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
+++ b/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
@@ -58,8 +58,9 @@ def llama_flash_attn_forward(
         deterministic (bool, optional): Whether to use deterministic algorithms. Defaults to False.
         head_first_stride (Optional[int], optional): A different (smaller) stride for the first group of heads.
             This is an optimization to increase communication/computation overlap. Defaults to None.
-        pack_first_stride (bool, optional): Whether to pack the first stride of key and value 
-            into a single all_gather to reduce overhead. Defaults to True.
+        pack_first_stride (bool, optional): Whether to pack the first stride of key and value
+            into a single all_gather to reduce overhead when `head_first_stride` is not None.
+            Has no effect if `head_first_stride` is None. Defaults to True.
 
     Returns:
         Tuple[torch.Tensor, torch.Tensor]: A tuple containing:

--- a/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
+++ b/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
@@ -96,11 +96,13 @@ def llama_flash_attn_forward(
         k_0 = k[:, :, :head_first_stride].contiguous()
         v_0 = v[:, :, :head_first_stride].contiguous()
 
-        # Allocate one smaller buffer for the first step
+        # Allocate one smaller buffer for the first step. 
+        # world_size is first to match NCCL's physical gathered memory layout.
         kv_buffer_small1_raw = torch.empty(
             (world_size, 2, batch_k, seq_k, head_first_stride, head_dim),
             dtype=k.dtype, device=k.device
         )
+        # Transpose to create a view matching the expected (2, world_size, ...) layout
         kv_buffer_small1 = kv_buffer_small1_raw.transpose(0, 1)
         # Allocate a second buffer for the second, non-standard step
         kv_buffer_small2 = torch.empty(
@@ -118,7 +120,9 @@ def llama_flash_attn_forward(
     comm = Comm(process_group)
     # Pass the main tensor slices to all_gather
     if head_first_stride is not None:
+        # Pack k_0 and v_0 to reduce NCCL launch overhead for the small first chunk
         send_kv_0 = torch.stack([k_0, v_0], dim=0).contiguous()
+        # Gather directly into the NCCL-aligned raw buffer
         comm.all_gather(kv_buffer_small1_raw, send_kv_0)
     else:
         comm.all_gather(initial_kv_buffer[0], k_0)

--- a/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
+++ b/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
@@ -34,6 +34,7 @@ def llama_flash_attn_forward(
     alibi_slopes: Optional[torch.Tensor] = None,
     deterministic: bool = False,
     head_first_stride: Optional[int] = None,
+    pack_first_stride: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """
     Llama-style flash attention forward pass with ring communication.
@@ -57,6 +58,8 @@ def llama_flash_attn_forward(
         deterministic (bool, optional): Whether to use deterministic algorithms. Defaults to False.
         head_first_stride (Optional[int], optional): A different (smaller) stride for the first group of heads.
             This is an optimization to increase communication/computation overlap. Defaults to None.
+        pack_first_stride (bool, optional): Whether to pack the first stride of key and value 
+            into a single all_gather to reduce overhead. Defaults to True.
 
     Returns:
         Tuple[torch.Tensor, torch.Tensor]: A tuple containing:
@@ -96,14 +99,20 @@ def llama_flash_attn_forward(
         k_0 = k[:, :, :head_first_stride].contiguous()
         v_0 = v[:, :, :head_first_stride].contiguous()
 
-        # Allocate one smaller buffer for the first step. 
-        # world_size is first to match NCCL's physical gathered memory layout.
-        kv_buffer_small1_raw = torch.empty(
-            (world_size, 2, batch_k, seq_k, head_first_stride, head_dim),
-            dtype=k.dtype, device=k.device
-        )
-        # Transpose to create a view matching the expected (2, world_size, ...) layout
-        kv_buffer_small1 = kv_buffer_small1_raw.transpose(0, 1)
+        if pack_first_stride:
+            # Allocate one smaller buffer for the first step. 
+            # world_size is first to match NCCL's physical gathered memory layout.
+            kv_buffer_small1_raw = torch.empty(
+                (world_size, 2, batch_k, seq_k, head_first_stride, head_dim),
+                dtype=k.dtype, device=k.device
+            )
+            # Transpose to create a view matching the expected (2, world_size, ...) layout
+            kv_buffer_small1 = kv_buffer_small1_raw.transpose(0, 1)
+        else:
+            kv_buffer_small1 = torch.empty(
+                (2, world_size, batch_k, seq_k, head_first_stride, head_dim),
+                dtype=k.dtype, device=k.device
+            )
         # Allocate a second buffer for the second, non-standard step
         kv_buffer_small2 = torch.empty(
             (2, world_size, batch_k, seq_k, heads_k_stride - head_first_stride, head_dim),
@@ -119,7 +128,7 @@ def llama_flash_attn_forward(
 
     comm = Comm(process_group)
     # Pass the main tensor slices to all_gather
-    if head_first_stride is not None:
+    if head_first_stride is not None and pack_first_stride:
         # Pack k_0 and v_0 to reduce NCCL launch overhead for the small first chunk
         send_kv_0 = torch.stack([k_0, v_0], dim=0).contiguous()
         # Gather directly into the NCCL-aligned raw buffer
@@ -448,6 +457,7 @@ class LlamaRingFlashAttnFunc(torch.autograd.Function):
         v: torch.Tensor,
         heads_k_stride: int,
         head_first_stride: Optional[int],
+        pack_first_stride: bool,
         dropout_p: float,
         softmax_scale: Optional[float],
         causal: bool,
@@ -471,6 +481,7 @@ class LlamaRingFlashAttnFunc(torch.autograd.Function):
             v (torch.Tensor): Value tensor.
             heads_k_stride (int): Stride for key/value heads in GQA/MQA.
             head_first_stride (Optional[int]): A different stride for the first group of heads.
+            pack_first_stride (bool): Whether to pack the first stride of key and value.
             dropout_p (float): Dropout probability.
             softmax_scale (Optional[float]): Scale factor for softmax. If None, calculated from head dimension.
             causal (bool): Whether to apply causal masking.
@@ -499,6 +510,7 @@ class LlamaRingFlashAttnFunc(torch.autograd.Function):
             v,
             heads_k_stride=heads_k_stride,
             head_first_stride=head_first_stride,
+            pack_first_stride=pack_first_stride,
             softmax_scale=softmax_scale,
             dropout_p=dropout_p,
             causal=causal,
@@ -558,8 +570,8 @@ class LlamaRingFlashAttnFunc(torch.autograd.Function):
         )
         if ctx.bwd_event_sync:
             time_event.synchronize()
-        # forward takes 14 args excluding ctx. return 3 grad + 11 None
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None
+        # forward takes 15 args excluding ctx. return 3 grad + 12 None
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None
 
 class LlamaFlashAttnFunc(torch.autograd.Function):
     """
@@ -573,6 +585,7 @@ class LlamaFlashAttnFunc(torch.autograd.Function):
         v: torch.Tensor,
         heads_k_stride: int,
         head_first_stride: Optional[int],
+        pack_first_stride: bool,
         dropout_p: float,
         softmax_scale: Optional[float],
         causal: bool,
@@ -596,6 +609,7 @@ class LlamaFlashAttnFunc(torch.autograd.Function):
             v (torch.Tensor): Value tensor.
             heads_k_stride (int): Stride for key/value heads in GQA/MQA.
             head_first_stride (Optional[int]): A different stride for the first group of heads.
+            pack_first_stride (bool): Whether to pack the first stride of key and value.
             dropout_p (float): Dropout probability.
             softmax_scale (Optional[float]): Scale factor for softmax. If None, calculated from head dimension.
             causal (bool): Whether to apply causal masking.
@@ -624,6 +638,7 @@ class LlamaFlashAttnFunc(torch.autograd.Function):
             v,
             heads_k_stride=heads_k_stride,
             head_first_stride=head_first_stride,
+            pack_first_stride=pack_first_stride,
             softmax_scale=softmax_scale,
             dropout_p=dropout_p,
             causal=causal,
@@ -668,8 +683,8 @@ class LlamaFlashAttnFunc(torch.autograd.Function):
         )
         if ctx.bwd_event_sync:
             time_event.synchronize()
-        # forward takes 14 args excluding ctx. return 3 grad + 11 None
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None
+        # forward takes 15 args excluding ctx. return 3 grad + 12 None
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None
 
 
 def llama_fwd_ring_bwd_flash_attn_func(
@@ -678,6 +693,7 @@ def llama_fwd_ring_bwd_flash_attn_func(
     v: torch.Tensor,
     heads_k_stride: int = 1,
     head_first_stride: Optional[int] = None,
+    pack_first_stride: bool = True,
     dropout_p: float = 0.0,
     softmax_scale: Optional[float] = None,
     causal: bool = False,
@@ -705,6 +721,8 @@ def llama_fwd_ring_bwd_flash_attn_func(
         head_first_stride (Optional[int], optional): A different stride for the first group of heads
             to improve communication/computation overlap. Defaults to None. 
             Must be smaller than heads_k_stride.
+        pack_first_stride (bool, optional): Whether to pack the first stride of key and value 
+            into a single all_gather to reduce overhead. Defaults to True.
         dropout_p (float, optional): Dropout probability. Defaults to 0.0.
         softmax_scale (Optional[float], optional): The scale factor for softmax. If None, it is
             calculated as `1.0 / sqrt(head_dim)`. Defaults to None.
@@ -730,6 +748,7 @@ def llama_fwd_ring_bwd_flash_attn_func(
         v,
         heads_k_stride,
         head_first_stride,
+        pack_first_stride,
         dropout_p,
         softmax_scale,
         causal,
@@ -747,6 +766,7 @@ def llama_flash_attn_func(
     v: torch.Tensor,
     heads_k_stride: int = 1,
     head_first_stride: Optional[int] = None,
+    pack_first_stride: bool = True,
     dropout_p: float = 0.0,
     softmax_scale: Optional[float] = None,
     causal: bool = False,
@@ -764,6 +784,7 @@ def llama_flash_attn_func(
         v,
         heads_k_stride,
         head_first_stride,
+        pack_first_stride,
         dropout_p,
         softmax_scale,
         causal,
@@ -873,6 +894,7 @@ class ConditionalLlamaFlashAttnFunc(torch.autograd.Function):
         v: torch.Tensor,
         heads_k_stride: int,
         head_first_stride: Optional[int],
+        pack_first_stride: bool,
         dropout_p: float,
         softmax_scale: Optional[float],
         causal: bool,
@@ -897,6 +919,7 @@ class ConditionalLlamaFlashAttnFunc(torch.autograd.Function):
             v (torch.Tensor): Value tensor.
             heads_k_stride (int): Stride for key/value heads in GQA/MQA.
             head_first_stride (Optional[int]): A different stride for the first group of heads.
+            pack_first_stride (bool): Whether to pack the first stride of key and value.
             dropout_p (float): Dropout probability.
             softmax_scale (Optional[float]): Scale factor for softmax. If None, calculated from head dimension.
             causal (bool): Whether to apply causal masking.
@@ -949,6 +972,7 @@ class ConditionalLlamaFlashAttnFunc(torch.autograd.Function):
                 v,
                 heads_k_stride=heads_k_stride,
                 head_first_stride=head_first_stride,
+                pack_first_stride=pack_first_stride,
                 softmax_scale=softmax_scale,
                 dropout_p=dropout_p,
                 causal=causal,
@@ -1022,8 +1046,8 @@ class ConditionalLlamaFlashAttnFunc(torch.autograd.Function):
             )
         if ctx.bwd_event_sync:
             time_event.synchronize()
-        # forward takes 14 args excluding ctx. return 3 grad + 11 None
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None
+        # forward takes 15 args excluding ctx. return 3 grad + 12 None
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None
 
 
 class ConditionalLlamaRingFlashAttnFunc(torch.autograd.Function):
@@ -1038,6 +1062,7 @@ class ConditionalLlamaRingFlashAttnFunc(torch.autograd.Function):
         v: torch.Tensor,
         heads_k_stride: int,
         head_first_stride: Optional[int],
+        pack_first_stride: bool,
         dropout_p: float,
         softmax_scale: Optional[float],
         causal: bool,
@@ -1062,6 +1087,7 @@ class ConditionalLlamaRingFlashAttnFunc(torch.autograd.Function):
             v (torch.Tensor): Value tensor.
             heads_k_stride (int): Stride for key/value heads in GQA/MQA.
             head_first_stride (Optional[int]): A different stride for the first group of heads.
+            pack_first_stride (bool): Whether to pack the first stride of key and value.
             dropout_p (float): Dropout probability.
             softmax_scale (Optional[float]): Scale factor for softmax. If None, calculated from head dimension.
             causal (bool): Whether to apply causal masking.
@@ -1114,6 +1140,7 @@ class ConditionalLlamaRingFlashAttnFunc(torch.autograd.Function):
                 v,
                 heads_k_stride=heads_k_stride,
                 head_first_stride=head_first_stride,
+                pack_first_stride=pack_first_stride,
                 softmax_scale=softmax_scale,
                 dropout_p=dropout_p,
                 causal=causal,
@@ -1149,6 +1176,7 @@ def cond_llama_fwd_ring_bwd_flash_attn_func(
     v: torch.Tensor,
     heads_k_stride: int = 1,
     head_first_stride: Optional[int] = None,
+    pack_first_stride: bool = True,
     dropout_p: float = 0.0,
     softmax_scale: Optional[float] = None,
     causal: bool = False,
@@ -1173,6 +1201,7 @@ def cond_llama_fwd_ring_bwd_flash_attn_func(
         v (torch.Tensor): Value tensor.
         heads_k_stride (int, optional): Stride for key/value heads. Defaults to 1.
         head_first_stride (Optional[int], optional): Different stride for the first group of heads. Defaults to None.
+        pack_first_stride (bool, optional): Whether to pack the first stride of key and value. Defaults to True.
         dropout_p (float, optional): Dropout probability. Defaults to 0.0.
         softmax_scale (Optional[float], optional): Softmax scale factor. Defaults to None.
         causal (bool, optional): Whether to apply causal masking. Defaults to False.
@@ -1192,6 +1221,7 @@ def cond_llama_fwd_ring_bwd_flash_attn_func(
         v,
         heads_k_stride,
         head_first_stride,
+        pack_first_stride,
         dropout_p,
         softmax_scale,
         causal,
@@ -1210,6 +1240,7 @@ def cond_llama_flash_attn_func(
     v: torch.Tensor,
     heads_k_stride: int = 1,
     head_first_stride: Optional[int] = None,
+    pack_first_stride: bool = True,
     dropout_p: float = 0.0,
     softmax_scale: Optional[float] = None,
     causal: bool = False,
@@ -1231,6 +1262,7 @@ def cond_llama_flash_attn_func(
         v,
         heads_k_stride,
         head_first_stride,
+        pack_first_stride,
         dropout_p,
         softmax_scale,
         causal,

--- a/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
+++ b/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
@@ -97,10 +97,11 @@ def llama_flash_attn_forward(
         v_0 = v[:, :, :head_first_stride].contiguous()
 
         # Allocate one smaller buffer for the first step
-        kv_buffer_small1 = torch.empty(
-            (2, world_size, batch_k, seq_k, head_first_stride, head_dim),
+        kv_buffer_small1_raw = torch.empty(
+            (world_size, 2, batch_k, seq_k, head_first_stride, head_dim),
             dtype=k.dtype, device=k.device
         )
+        kv_buffer_small1 = kv_buffer_small1_raw.transpose(0, 1)
         # Allocate a second buffer for the second, non-standard step
         kv_buffer_small2 = torch.empty(
             (2, world_size, batch_k, seq_k, heads_k_stride - head_first_stride, head_dim),
@@ -116,8 +117,12 @@ def llama_flash_attn_forward(
 
     comm = Comm(process_group)
     # Pass the main tensor slices to all_gather
-    comm.all_gather(initial_kv_buffer[0], k_0)
-    comm.all_gather(initial_kv_buffer[1], v_0)
+    if head_first_stride is not None:
+        send_kv_0 = torch.stack([k_0, v_0], dim=0).contiguous()
+        comm.all_gather(kv_buffer_small1_raw, send_kv_0)
+    else:
+        comm.all_gather(initial_kv_buffer[0], k_0)
+        comm.all_gather(initial_kv_buffer[1], v_0)
 
     current_head = 0
     for step, stride in enumerate(stride_pattern):
@@ -181,8 +186,8 @@ def llama_flash_attn_forward(
             k_i = rearrange(k_i, 'w b s hs dh -> b (w s) hs dh')
             v_i = rearrange(v_i, 'w b s hs dh -> b (w s) hs dh')
         else:
-            k_i = rearrange(current_kv_buffer[0], "w b s hs dh -> b (w s) hs dh")
-            v_i = rearrange(current_kv_buffer[1], "w b s hs dh -> b (w s) hs dh")
+            k_i = rearrange(current_kv_buffer[0].contiguous(), "w b s hs dh -> b (w s) hs dh")
+            v_i = rearrange(current_kv_buffer[1].contiguous(), "w b s hs dh -> b (w s) hs dh")
 
         # params = get_default_args(_flash_attn_varlen_forward).copy()
         params = {

--- a/test/test.sh
+++ b/test/test.sh
@@ -12,6 +12,8 @@ tests=(
   test_stripe_flash_attn_func.py
   test_zigzag_ring_flash_attn_func.py
   test_zigzag_ring_flash_attn_varlen_func.py
+  test_cond_llama_fwd_ring_bwd_flash_attn.py
+  test_pack_first_stride.py
 )
 
 for test in "${tests[@]}"; do

--- a/test/test_pack_first_stride.py
+++ b/test/test_pack_first_stride.py
@@ -1,0 +1,115 @@
+import sys
+import torch
+import torch.distributed as dist
+from flash_attn import flash_attn_qkvpacked_func
+from ring_flash_attn.llama_fwd_ring_bwd_flash_attn import llama_fwd_ring_bwd_flash_attn_func
+from utils import log, set_seed
+
+def main():
+    dist.init_process_group("nccl")
+    rank = dist.get_rank()
+    set_seed(rank)
+    world_size = dist.get_world_size()
+    dtype = torch.bfloat16
+    device = torch.device(f"cuda:{rank}")
+
+    batch_size = 8
+    seqlen = 3816
+    nheads = 6
+    d = 128
+    dropout_p = 0
+    causal = False
+    deterministic = False
+
+    assert seqlen % world_size == 0
+    assert d % 8 == 0
+
+    # --- Setup Inputs ---
+    qkv = torch.randn(
+        batch_size, seqlen, 3, nheads, d, device=device, dtype=dtype, requires_grad=True
+    )
+    dist.broadcast(qkv, src=0)
+
+    dout = torch.randn(batch_size, seqlen, nheads, d, device=device, dtype=dtype)
+    dist.broadcast(dout, src=0)
+
+    # Create local shards (detached from global graph for fresh start)
+    # We create two identical local sets to test the two branches separately without mixing grads
+    local_qkv_true = qkv.chunk(world_size, dim=1)[rank].detach().clone()
+    local_qkv_true.requires_grad = True
+
+    local_qkv_false = qkv.chunk(world_size, dim=1)[rank].detach().clone()
+    local_qkv_false.requires_grad = True
+
+    local_dout = dout.chunk(world_size, dim=1)[rank].detach().clone()
+
+    dist.barrier()
+
+    if rank == 0:
+        print("#" * 30)
+        print("# forward:")
+        print("#" * 30)
+
+    # --- Test Subject: Pack First Stride = True ---
+    fn = llama_fwd_ring_bwd_flash_attn_func
+    
+    out_true, lse_true, _ = fn(
+        local_qkv_true[:,:,0], 
+        local_qkv_true[:,:,1], 
+        local_qkv_true[:,:,2], 
+        heads_k_stride=3,
+        head_first_stride=1,
+        pack_first_stride=True,
+        bwd_event_sync=False,
+        dropout_p=dropout_p,
+        causal=causal,
+        window_size=(-1, -1),
+        alibi_slopes=None,
+        deterministic=deterministic,
+        return_attn_probs=True,
+    )
+
+    # --- Test Subject: Pack First Stride = False ---
+    out_false, lse_false, _ = fn(
+        local_qkv_false[:,:,0], 
+        local_qkv_false[:,:,1], 
+        local_qkv_false[:,:,2], 
+        heads_k_stride=3,
+        head_first_stride=1,
+        pack_first_stride=False,
+        bwd_event_sync=False,
+        dropout_p=dropout_p,
+        causal=causal,
+        window_size=(-1, -1),
+        alibi_slopes=None,
+        deterministic=deterministic,
+        return_attn_probs=True,
+    )
+
+    log("out true", out_true, rank0_only=True)
+    log("out diff (True vs False)", out_true - out_false)
+    log("lse diff (True vs False)", lse_true - lse_false) 
+
+    dist.barrier()
+    if rank == 0:
+        print("#" * 30)
+        print("# backward:")
+        print("#" * 30)
+
+    out_true.backward(local_dout)
+    dqkv_true = local_qkv_true.grad
+
+    out_false.backward(local_dout)
+    dqkv_false = local_qkv_false.grad
+
+    log("dq diff (True vs False)", dqkv_true[:, :, 0] - dqkv_false[:, :, 0])
+    log("dk diff (True vs False)", dqkv_true[:, :, 1] - dqkv_false[:, :, 1])
+    log("dv diff (True vs False)", dqkv_true[:, :, 2] - dqkv_false[:, :, 2])
+
+    dist.destroy_process_group()
+
+if __name__ == "__main__":
+    if len(sys.argv) > 1 and sys.argv[1] == "compile":
+        torch._dynamo.config.capture_scalar_outputs = True
+        llama_fwd_ring_bwd_flash_attn_func = torch.compile(llama_fwd_ring_bwd_flash_attn_func)
+    main()

--- a/test/test_pack_first_stride.py
+++ b/test/test_pack_first_stride.py
@@ -1,7 +1,6 @@
 import sys
 import torch
 import torch.distributed as dist
-from flash_attn import flash_attn_qkvpacked_func
 from ring_flash_attn.llama_fwd_ring_bwd_flash_attn import llama_fwd_ring_bwd_flash_attn_func
 from utils import log, set_seed
 


### PR DESCRIPTION
This pull request refactors the way small buffer allocations and NCCL communication are handled for the first step in `llama_flash_attn_forward` in `ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py`. The changes optimize buffer layout to match NCCL expectations, reduce launch overhead, and ensure correct tensor memory layouts.

**NCCL Communication and Buffer Layout Improvements:**

* The allocation of the first small buffer (`kv_buffer_small1`) is changed so that `world_size` is the leading dimension, which matches NCCL's physical gathered memory layout. A raw buffer is allocated and then transposed to the expected logical view.
* The all-gather operation for the first chunk now packs `k_0` and `v_0` together using `torch.stack` to reduce NCCL launch overhead, and gathers directly into the NCCL-aligned raw buffer.

**Tensor Layout and Memory Contiguity:**

* When rearranging tensors from the gathered buffer, `.contiguous()` is now called explicitly to ensure correct memory layout before applying `rearrange`, preventing potential runtime errors or performance issues.