### PR TITLE
Llama bwd fix opt3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,73 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+Ring Flash Attention is a distributed attention library implementing sequence parallelism across multiple GPUs. It wraps `flash_attn` primitives inside a ring-topology communication pattern so each GPU holds only a shard of Q/K/V while maintaining numerically correct attention across all ranks.
+
+## Commands
+
+**Install from source:**
+```bash
+pip install .
+```
+
+**Run a single test (requires 8 GPUs by default):**
+```bash
+torchrun --nproc_per_node 8 test/test_ring_flash_attn_func.py
+torchrun --nproc_per_node 4 test/test_llama_flash_attn.py
+```
+
+**Run the full test suite (also runs with `torch.compile`):**
+```bash
+bash test/test.sh
+```
+
+**Benchmarks:**
+```bash
+torchrun --nproc_per_node 8 benchmark/benchmark_varlen_kvpacked_func.py
+```
+
+**Formatting:**
+```bash
+black .
+```
+
+## Architecture
+
+### Attention variants (ring_flash_attn/)
+
+Each variant is a self-contained module with matching `*_func`, `*_kvpacked_func`, and `*_qkvpacked_func` entry points:
+
+| Module | API | Notes |
+|---|---|---|
+| `ring_flash_attn.py` | batch | Baseline ring attention |
+| `ring_flash_attn_varlen.py` | varlen | Variable-length / packed sequences |
+| `zigzag_ring_flash_attn.py` | batch | Causal only; 85% efficiency on H800 (vs 52% baseline) |
+| `zigzag_ring_flash_attn_varlen.py` | varlen | Zigzag + packed sequences |
+| `stripe_flash_attn.py` | batch | Stripe variant (arXiv 2311.09431); causal only |
+| `llama3_flash_attn_varlen.py` | varlen | Llama3 context parallelism (arXiv 2407.21783); **recommended for most use cases** |
+| `llama_fwd_ring_bwd_flash_attn.py` | varlen | Hybrid: ring forward, flash backward; lower memory |
+
+### Core abstractions (ring_flash_attn/utils.py)
+
+- **`RingComm`** — P2P send/recv over a `torch.distributed` process group arranged in a ring. `send_recv()` / `send_recv_kv()` overlap compute and communication; `commit()` + `wait()` finalize transfers.
+- **`AllGatherComm`** — wraps collective all-gather in the same interface so callers can swap communication strategies.
+- **`update_out_and_lse()`** — numerically-stable LogSumExp accumulation that merges a new attention block result into the running output and LSE tensors. This is the heart of the numerically-correct ring reduction.
+- **`flatten_varlen_lse()` / `unflatten_varlen_lse()`** — reshape LSE tensors between flash_attn's `(batch, heads, seqlen)` layout and the packed varlen layout.
+
+### HuggingFace adapter (ring_flash_attn/adapters/hf_adapter.py)
+
+`substitute_hf_flash_attn()` monkey-patches HF attention modules at runtime to route through ring attention. `DATA_PARAMS` is a module-level dict that conveys `cu_seqlens` and related state across rank boundaries during forward passes. Call `update_ring_flash_attn_params()` before each forward step and toggle `use_ring_attn` to switch between ring and vanilla flash attention.
+
+### Triton kernels (ring_flash_attn/triton_utils.py)
+
+`flatten_kernel` / `unflatten_kernel` are Triton implementations of the LSE reshape operations, used instead of the PyTorch versions when available.
+
+### Key design constraints
+
+- **No dropout support** — saving RNG states across all ring ranks is not implemented.
+- **No sliding-window attention** — the varlen implementation does not support `window_size`.
+- **fp32 LSE buffer** — outputs accumulate in fp32 to avoid bf16 precision loss; this increases memory above the theoretical minimum.
+- All tests use `torchrun` with NCCL; NVLink is required for competitive throughput.

--- a/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
+++ b/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
@@ -258,8 +258,8 @@ def llama_flash_attn_backward(
     softcap=0.0,
     alibi_slopes=None,
     deterministic=False,
-    head_first_stride: Optional[int] = None,
-    head_last_stride: Optional[int] = None,
+    bwd_head_first_stride: Optional[int] = None,
+    bwd_head_last_stride: Optional[int] = None,
     time_event=None,
 ):
     """
@@ -269,10 +269,10 @@ def llama_flash_attn_backward(
     across a process group using all-gather operations and aggregating dk/dv via reduce_scatter.
 
     Communication is overlapped with compute on both ends:
-    - The first iteration's all_gather can be shrunk via `head_first_stride` (mirroring forward),
-      splitting the first chunk into [head_first_stride, heads_k_stride - head_first_stride].
-    - The last iteration's reduce_scatter can be shrunk via `head_last_stride`, splitting the
-      last chunk into [heads_k_stride - head_last_stride, head_last_stride].
+        - The first iteration's all_gather can be shrunk via `bwd_head_first_stride`,
+            splitting the first chunk into [bwd_head_first_stride, heads_k_stride - bwd_head_first_stride].
+        - The last iteration's reduce_scatter can be shrunk via `bwd_head_last_stride`, splitting the
+            last chunk into [heads_k_stride - bwd_head_last_stride, bwd_head_last_stride].
     - All interior reduce_scatters run async and overlap with the next iteration's
       flash_attn_backward; only the final, optionally smaller, reduce_scatter is exposed.
 
@@ -292,9 +292,9 @@ def llama_flash_attn_backward(
         softcap (float, optional): Softcap for attention scores. Defaults to 0.0.
         alibi_slopes (Optional[torch.Tensor], optional): ALiBi slopes for positional bias. Defaults to None.
         deterministic (bool, optional): Whether to use deterministic algorithms. Defaults to False.
-        head_first_stride (Optional[int], optional): Smaller stride for the first iteration to reduce
+        bwd_head_first_stride (Optional[int], optional): Smaller stride for the first backward iteration to reduce
             the size of the un-overlapped initial all_gather. Must be in (0, heads_k_stride). Defaults to None.
-        head_last_stride (Optional[int], optional): Smaller stride for the last iteration to reduce
+        bwd_head_last_stride (Optional[int], optional): Smaller stride for the last backward iteration to reduce
             the size of the un-overlapped final reduce_scatter. Must be in (0, heads_k_stride). Defaults to None.
         time_event (Optional[torch.cuda.Event], optional): CUDA event for timing or synchronization. Defaults to None.
 
@@ -311,27 +311,27 @@ def llama_flash_attn_backward(
 
     # ---- Build stride pattern (mirrors forward, extended for the tail) ----
     n_full = nheads_k // heads_k_stride
-    if head_first_stride is not None:
-        assert 0 < head_first_stride < heads_k_stride, (
-            "head_first_stride must be between 0 and heads_k_stride"
+    if bwd_head_first_stride is not None:
+        assert 0 < bwd_head_first_stride < heads_k_stride, (
+            "bwd_head_first_stride must be between 0 and heads_k_stride"
         )
-        first_part = [head_first_stride, heads_k_stride - head_first_stride]
+        first_part = [bwd_head_first_stride, heads_k_stride - bwd_head_first_stride]
         n_full -= 1
     else:
         first_part = []
 
-    if head_last_stride is not None:
-        assert 0 < head_last_stride < heads_k_stride, (
-            "head_last_stride must be between 0 and heads_k_stride"
+    if bwd_head_last_stride is not None:
+        assert 0 < bwd_head_last_stride < heads_k_stride, (
+            "bwd_head_last_stride must be between 0 and heads_k_stride"
         )
-        last_part = [heads_k_stride - head_last_stride, head_last_stride]
+        last_part = [heads_k_stride - bwd_head_last_stride, bwd_head_last_stride]
         n_full -= 1
     else:
         last_part = []
 
     assert n_full >= 0, (
         f"nheads_k={nheads_k}, heads_k_stride={heads_k_stride} too small to fit "
-        f"both head_first_stride and head_last_stride splits"
+        f"both bwd_head_first_stride and bwd_head_last_stride splits"
     )
 
     stride_pattern = first_part + [heads_k_stride] * n_full + last_part
@@ -365,17 +365,17 @@ def llama_flash_attn_backward(
     kv_bufs_per_step = [None] * n_steps
     if n_first >= 1:
         kv_bufs_per_step[0] = torch.empty(
-            kv_shape(head_first_stride), dtype=k.dtype, device=k.device
+            kv_shape(bwd_head_first_stride), dtype=k.dtype, device=k.device
         )
         kv_bufs_per_step[1] = torch.empty(
-            kv_shape(heads_k_stride - head_first_stride), dtype=k.dtype, device=k.device
+            kv_shape(heads_k_stride - bwd_head_first_stride), dtype=k.dtype, device=k.device
         )
     if n_last >= 1:
         kv_bufs_per_step[n_steps - 2] = torch.empty(
-            kv_shape(heads_k_stride - head_last_stride), dtype=k.dtype, device=k.device
+            kv_shape(heads_k_stride - bwd_head_last_stride), dtype=k.dtype, device=k.device
         )
         kv_bufs_per_step[n_steps - 1] = torch.empty(
-            kv_shape(head_last_stride), dtype=k.dtype, device=k.device
+            kv_shape(bwd_head_last_stride), dtype=k.dtype, device=k.device
         )
 
     if middle_end > middle_start:
@@ -681,7 +681,8 @@ class LlamaFlashAttnFunc(torch.autograd.Function):
         heads_k_stride: int,
         head_first_stride: Optional[int],
         pack_first_stride: bool,
-        head_last_stride: Optional[int],
+        bwd_head_first_stride: Optional[int],
+        bwd_head_last_stride: Optional[int],
         dropout_p: float,
         softmax_scale: Optional[float],
         causal: bool,
@@ -752,8 +753,8 @@ class LlamaFlashAttnFunc(torch.autograd.Function):
         ctx.group = group
         ctx.bwd_event_sync = bwd_event_sync
         ctx.heads_k_stride = heads_k_stride
-        ctx.head_first_stride = head_first_stride
-        ctx.head_last_stride = head_last_stride
+        ctx.bwd_head_first_stride = bwd_head_first_stride
+        ctx.bwd_head_last_stride = bwd_head_last_stride
         return out if not return_softmax else (out, softmax_lse, None)
 
     @staticmethod
@@ -777,14 +778,14 @@ class LlamaFlashAttnFunc(torch.autograd.Function):
             window_size=ctx.window_size,
             alibi_slopes=ctx.alibi_slopes,
             deterministic=ctx.deterministic,
-            head_first_stride=ctx.head_first_stride,
-            head_last_stride=ctx.head_last_stride,
+            bwd_head_first_stride=ctx.bwd_head_first_stride,
+            bwd_head_last_stride=ctx.bwd_head_last_stride,
             time_event=time_event,
         )
         if ctx.bwd_event_sync:
             time_event.synchronize()
-        # forward takes 16 args excluding ctx. return 3 grad + 13 None
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None
+        # forward takes 17 args excluding ctx. return 3 grad + 14 None
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None, None
 
 
 def llama_fwd_ring_bwd_flash_attn_func(
@@ -867,7 +868,8 @@ def llama_flash_attn_func(
     heads_k_stride: int = 1,
     head_first_stride: Optional[int] = None,
     pack_first_stride: bool = True,
-    head_last_stride: Optional[int] = None,
+    bwd_head_first_stride: Optional[int] = None,
+    bwd_head_last_stride: Optional[int] = None,
     dropout_p: float = 0.0,
     softmax_scale: Optional[float] = None,
     causal: bool = False,
@@ -886,7 +888,8 @@ def llama_flash_attn_func(
         heads_k_stride,
         head_first_stride,
         pack_first_stride,
-        head_last_stride,
+        bwd_head_first_stride,
+        bwd_head_last_stride,
         dropout_p,
         softmax_scale,
         causal,
@@ -997,7 +1000,8 @@ class ConditionalLlamaFlashAttnFunc(torch.autograd.Function):
         heads_k_stride: int,
         head_first_stride: Optional[int],
         pack_first_stride: bool,
-        head_last_stride: Optional[int],
+        bwd_head_first_stride: Optional[int],
+        bwd_head_last_stride: Optional[int],
         dropout_p: float,
         softmax_scale: Optional[float],
         causal: bool,
@@ -1095,8 +1099,8 @@ class ConditionalLlamaFlashAttnFunc(torch.autograd.Function):
         ctx.deterministic = deterministic
         ctx.group = group
         ctx.heads_k_stride = heads_k_stride
-        ctx.head_first_stride = head_first_stride
-        ctx.head_last_stride = head_last_stride
+        ctx.bwd_head_first_stride = bwd_head_first_stride
+        ctx.bwd_head_last_stride = bwd_head_last_stride
         return out if not return_softmax else (out, softmax_lse, None)
 
     @staticmethod
@@ -1149,14 +1153,14 @@ class ConditionalLlamaFlashAttnFunc(torch.autograd.Function):
                 window_size=ctx.window_size,
                 alibi_slopes=ctx.alibi_slopes,
                 deterministic=ctx.deterministic,
-                head_first_stride=ctx.head_first_stride,
-                head_last_stride=ctx.head_last_stride,
+                bwd_head_first_stride=ctx.bwd_head_first_stride,
+                bwd_head_last_stride=ctx.bwd_head_last_stride,
                 time_event=time_event,
             )
         if ctx.bwd_event_sync:
             time_event.synchronize()
-        # forward takes 16 args excluding ctx. return 3 grad + 13 None
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None
+        # forward takes 17 args excluding ctx. return 3 grad + 14 None
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None, None
 
 
 class ConditionalLlamaRingFlashAttnFunc(torch.autograd.Function):
@@ -1352,7 +1356,8 @@ def cond_llama_flash_attn_func(
     heads_k_stride: int = 1,
     head_first_stride: Optional[int] = None,
     pack_first_stride: bool = True,
-    head_last_stride: Optional[int] = None,
+    bwd_head_first_stride: Optional[int] = None,
+    bwd_head_last_stride: Optional[int] = None,
     dropout_p: float = 0.0,
     softmax_scale: Optional[float] = None,
     causal: bool = False,
@@ -1375,7 +1380,8 @@ def cond_llama_flash_attn_func(
         heads_k_stride,
         head_first_stride,
         pack_first_stride,
-        head_last_stride,
+        bwd_head_first_stride,
+        bwd_head_last_stride,
         dropout_p,
         softmax_scale,
         causal,

--- a/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
+++ b/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
@@ -415,6 +415,10 @@ def llama_flash_attn_backward(
     dv = torch.empty_like(v)
 
     comm = Comm(process_group)
+    # Dedicated stream for reduce_scatter so collectives run concurrently with
+    # flash_attn_backward on the compute stream (avoids inserting cudaStreamWaitEvent
+    # on the compute stream when draining Work handles).
+    comm_stream = torch.cuda.Stream()
 
     # ---- Initial all_gather for step 0 ----
     first_stride_size = stride_pattern[0]
@@ -523,10 +527,16 @@ def llama_flash_attn_backward(
 
         # ---- Drain the previous iteration's async reduce_scatter ----
         # Done AFTER flash_attn_backward so they overlap on the GPU.
+        # Wait on comm_stream (not compute stream) so cudaStreamWaitEvent is NOT
+        # inserted on the compute stream, preserving compute/NCCL overlap.
         if prev_handles is not None:
             prev_h_dk, prev_h_dv, prev_slot, prev_i, prev_stride_w = prev_handles
-            prev_h_dk.wait()
-            prev_h_dv.wait()
+            with torch.cuda.stream(comm_stream):
+                prev_h_dk.wait()
+                prev_h_dv.wait()
+                _comm_done = torch.cuda.Event()
+                _comm_done.record()
+            torch.cuda.current_stream().wait_event(_comm_done)
             prev_out = reduce_out_slots[prev_stride_w][prev_slot]
             dk[:, :, prev_i:prev_i + prev_stride_w].copy_(prev_out[0])
             dv[:, :, prev_i:prev_i + prev_stride_w].copy_(prev_out[1])
@@ -543,12 +553,18 @@ def llama_flash_attn_backward(
         reduce_out = reduce_out_slots[stride_i][slot]
         scatter_in.copy_(grad_permuted)
 
-        h_dk = dist.reduce_scatter_tensor(
-            reduce_out[0], scatter_in[0], group=process_group, async_op=True
-        )
-        h_dv = dist.reduce_scatter_tensor(
-            reduce_out[1], scatter_in[1], group=process_group, async_op=True
-        )
+        # Signal to comm_stream that scatter_in is ready on the compute stream.
+        _compute_ready = torch.cuda.Event()
+        _compute_ready.record()
+        comm_stream.wait_event(_compute_ready)
+
+        with torch.cuda.stream(comm_stream):
+            h_dk = dist.reduce_scatter_tensor(
+                reduce_out[0], scatter_in[0], group=process_group, async_op=True
+            )
+            h_dv = dist.reduce_scatter_tensor(
+                reduce_out[1], scatter_in[1], group=process_group, async_op=True
+            )
         prev_handles = (h_dk, h_dv, slot, i, stride_i)
 
         if step == 0 and time_event is not None:
@@ -557,8 +573,12 @@ def llama_flash_attn_backward(
     # ---- Drain the final reduce_scatter ----
     if prev_handles is not None:
         prev_h_dk, prev_h_dv, prev_slot, prev_i, prev_stride_w = prev_handles
-        prev_h_dk.wait()
-        prev_h_dv.wait()
+        with torch.cuda.stream(comm_stream):
+            prev_h_dk.wait()
+            prev_h_dv.wait()
+            _comm_done = torch.cuda.Event()
+            _comm_done.record()
+        torch.cuda.current_stream().wait_event(_comm_done)
         prev_out = reduce_out_slots[prev_stride_w][prev_slot]
         dk[:, :, prev_i:prev_i + prev_stride_w].copy_(prev_out[0])
         dv[:, :, prev_i:prev_i + prev_stride_w].copy_(prev_out[1])

--- a/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
+++ b/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
@@ -300,26 +300,24 @@ def llama_flash_attn_backward(
 
     # Buffer for gradients coming OUT of Flash Attention.
     # Shape: [Batch, Seq * WorldSize, Heads, HeadDim]
-    # Use float32 so that the gradients written by flash_attn backward retain full precision
-    # before the reduce_scatter accumulation step. Using k.dtype (bf16/fp16) here would
-    # quantize each per-rank gradient to low precision before the cross-rank summation.
-    # Note: this doubles the memory of this buffer vs. k.dtype.
+    # Must match k.dtype: flash_attn backward requires dk/dv to have the same dtype as k/v.
     dkv_buffer = torch.empty(
         (2, batch_k, seq_k * world_size, heads_k_stride, head_dim),
-        dtype=torch.float32,
+        dtype=k.dtype,
         device=k.device,
     )
 
-    # Contiguous staging buffer for reduce_scatter input.
-    # reduce_scatter_tensor requires a contiguous tensor; dkv_buffer's permuted view is not.
-    # Both this and dkv_buffer are float32, so the copy_ is lossless.
+    # Contiguous fp32 staging buffer for reduce_scatter input.
+    # Two purposes: (1) reduce_scatter_tensor requires a contiguous tensor, and
+    # dkv_buffer's permuted view is not contiguous; (2) the copy_ upcasts from
+    # k.dtype (bf16/fp16) to fp32 so the cross-rank summation is done in full precision.
     scatter_input_buffer = torch.empty(
         (2, world_size, batch_k, seq_k, heads_k_stride, head_dim),
         dtype=torch.float32,
         device=k.device,
     )
 
-    # Buffer for output of reduce_scatter (float32 for numerical stability of the cross-rank sum)
+    # Buffer for output of reduce_scatter (fp32, matching scatter_input_buffer)
     dkv_reduce_output_buffer = torch.empty(
         (2, batch_k, seq_k, heads_k_stride, head_dim),
         dtype=torch.float32,
@@ -424,6 +422,7 @@ def llama_flash_attn_backward(
         grad_view = dkv_buffer.view(2, batch_k, world_size, seq_k, heads_k_stride, head_dim)
         # 2. Permute: Swap B and W. Shape: [2, W, B, S, H, D]
         grad_permuted = grad_view.permute(0, 2, 1, 3, 4, 5)
+        # if scatter_input_buffer in fp32, precision gets promoted
         scatter_input_buffer.copy_(grad_permuted)
 
         # dist.reduce_scatter_tensor concat, gather, reduce on dim=0

--- a/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
+++ b/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
@@ -298,23 +298,28 @@ def llama_flash_attn_backward(
     )
     kv_buffer_copy = torch.empty_like(kv_buffer)
 
-    # Buffer for gradients coming OUT of Flash Attention
+    # Buffer for gradients coming OUT of Flash Attention.
     # Shape: [Batch, Seq * WorldSize, Heads, HeadDim]
+    # Use float32 so that the gradients written by flash_attn backward retain full precision
+    # before the reduce_scatter accumulation step. Using k.dtype (bf16/fp16) here would
+    # quantize each per-rank gradient to low precision before the cross-rank summation.
+    # Note: this doubles the memory of this buffer vs. k.dtype.
     dkv_buffer = torch.empty(
         (2, batch_k, seq_k * world_size, heads_k_stride, head_dim),
-        dtype=k.dtype,
+        dtype=torch.float32,
         device=k.device,
-    ) 
+    )
 
-    # Buffer for input to reduce_scatter (Needs to be rank-contiguous)
+    # Contiguous staging buffer for reduce_scatter input.
+    # reduce_scatter_tensor requires a contiguous tensor; dkv_buffer's permuted view is not.
+    # Both this and dkv_buffer are float32, so the copy_ is lossless.
     scatter_input_buffer = torch.empty(
         (2, world_size, batch_k, seq_k, heads_k_stride, head_dim),
         dtype=torch.float32,
         device=k.device,
     )
 
-    # Buffer for output of reduce_scatter (Float32 for stability)
-    # We use this regardless of stride since dk.float() would require full copies
+    # Buffer for output of reduce_scatter (float32 for numerical stability of the cross-rank sum)
     dkv_reduce_output_buffer = torch.empty(
         (2, batch_k, seq_k, heads_k_stride, head_dim),
         dtype=torch.float32,

--- a/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
+++ b/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
@@ -4,7 +4,11 @@ from flash_attn.flash_attn_interface import _flash_attn_forward, _flash_attn_bac
 from .ring_flash_attn import ring_flash_attn_backward
 from einops import rearrange
 from typing import Optional, Tuple
-from .utils import get_default_args, AllGatherComm as Comm
+from .utils import (
+    get_default_args,
+    AllGatherComm as Comm,
+    ReduceScatterHandleManager,
+)
 import logging
 import torch.distributed._tensor as distp_tensor
 import flash_attn
@@ -356,9 +360,6 @@ def llama_flash_attn_backward(
     def scatter_in_shape(width):
         return (2, world_size, batch_k, seq_k, width, head_dim)
 
-    def reduce_out_shape(width):
-        return (2, batch_k, seq_k, width, head_dim)
-
     # KV all_gather destinations: dedicated buffers for first/last small steps,
     # double-buffered swap pair (kv_buf_main / kv_buf_copy) shared across middle steps.
     kv_bufs_per_step = [None] * n_steps
@@ -392,33 +393,22 @@ def llama_flash_attn_backward(
         for w in unique_widths
     }
 
-    # Reduce_scatter staging buffers (fp32 for cross-rank precision).
-    # Two slots per width to ping-pong while the previous reduce_scatter is in flight.
-    scatter_in_slots = {
-        w: [
-            torch.empty(scatter_in_shape(w), dtype=torch.float32, device=k.device)
-            for _ in range(2)
-        ]
+    # fp32 staging buffers for cross-rank precision before reduce_scatter.
+    scatter_in_by_width = {
+        w: torch.empty(scatter_in_shape(w), dtype=torch.float32, device=k.device)
         for w in unique_widths
     }
-    reduce_out_slots = {
-        w: [
-            torch.empty(reduce_out_shape(w), dtype=torch.float32, device=k.device)
-            for _ in range(2)
-        ]
-        for w in unique_widths
-    }
-    next_slot_by_width = {w: 0 for w in unique_widths}
 
     dq = torch.empty_like(q)
     dk = torch.empty_like(k)
     dv = torch.empty_like(v)
 
     comm = Comm(process_group)
-    # Dedicated stream for reduce_scatter so collectives run concurrently with
-    # flash_attn_backward on the compute stream (avoids inserting cudaStreamWaitEvent
-    # on the compute stream when draining Work handles).
-    comm_stream = torch.cuda.Stream()
+    use_coalesced_reduce_scatter = os.getenv("RFA_USE_RS_COALESCED", "1") != "0"
+    rs_manager = ReduceScatterHandleManager(
+        group=process_group,
+        use_coalesced=use_coalesced_reduce_scatter,
+    )
 
     # ---- Initial all_gather for step 0 ----
     first_stride_size = stride_pattern[0]
@@ -431,9 +421,6 @@ def llama_flash_attn_backward(
         first_dst = kv_buf_main
     comm.all_gather(first_dst[0], k_0)
     comm.all_gather(first_dst[1], v_0)
-
-    # ---- Pipeline state: previous iteration's in-flight reduce_scatter ----
-    prev_handles = None  # (handle_dk, handle_dv, slot, i, stride_w)
 
     for step, (i, stride_i) in enumerate(zip(head_offsets, stride_pattern)):
         comm.wait()
@@ -525,61 +512,23 @@ def llama_flash_attn_backward(
         _wrapped_flash_attn_backward(**params)
         del k_i, v_i, q_i, dout_i, out_i
 
-        # ---- Drain the previous iteration's async reduce_scatter ----
-        # Done AFTER flash_attn_backward so they overlap on the GPU.
-        # Wait on comm_stream (not compute stream) so cudaStreamWaitEvent is NOT
-        # inserted on the compute stream, preserving compute/NCCL overlap.
-        if prev_handles is not None:
-            prev_h_dk, prev_h_dv, prev_slot, prev_i, prev_stride_w = prev_handles
-            with torch.cuda.stream(comm_stream):
-                prev_h_dk.wait()
-                prev_h_dv.wait()
-                _comm_done = torch.cuda.Event()
-                _comm_done.record()
-            torch.cuda.current_stream().wait_event(_comm_done)
-            prev_out = reduce_out_slots[prev_stride_w][prev_slot]
-            dk[:, :, prev_i:prev_i + prev_stride_w].copy_(prev_out[0])
-            dv[:, :, prev_i:prev_i + prev_stride_w].copy_(prev_out[1])
+        # Drain previous iteration's reduce_scatter after compute to keep issue/wait cadence.
+        rs_manager.drain_to(dk, dv)
 
         # ---- Stage and issue THIS iteration's async reduce_scatter ----
         # Permute (2, B, W*S, H, D) -> (2, W, B, S, H, D) and upcast to fp32 via copy_.
         grad_view = dkv_buf.view(2, batch_k, world_size, seq_k, stride_i, head_dim)
         grad_permuted = grad_view.permute(0, 2, 1, 3, 4, 5)
 
-        slot = next_slot_by_width[stride_i]
-        next_slot_by_width[stride_i] = 1 - slot
-
-        scatter_in = scatter_in_slots[stride_i][slot]
-        reduce_out = reduce_out_slots[stride_i][slot]
+        scatter_in = scatter_in_by_width[stride_i]
         scatter_in.copy_(grad_permuted)
-
-        # Issue from compute stream so NCCL automatically captures the scatter_in.copy_()
-        # dependency. NCCL runs on its own internal stream regardless of the calling stream;
-        # Work.wait() is called from comm_stream (see drain below) so compute_stream is
-        # never blocked by NCCL completion.
-        h_dk = dist.reduce_scatter_tensor(
-            reduce_out[0], scatter_in[0], group=process_group, async_op=True
-        )
-        h_dv = dist.reduce_scatter_tensor(
-            reduce_out[1], scatter_in[1], group=process_group, async_op=True
-        )
-        prev_handles = (h_dk, h_dv, slot, i, stride_i)
+        rs_manager.issue(scatter_in[0], scatter_in[1], i, stride_i)
 
         if step == 0 and time_event is not None:
             time_event.record()
 
     # ---- Drain the final reduce_scatter ----
-    if prev_handles is not None:
-        prev_h_dk, prev_h_dv, prev_slot, prev_i, prev_stride_w = prev_handles
-        with torch.cuda.stream(comm_stream):
-            prev_h_dk.wait()
-            prev_h_dv.wait()
-            _comm_done = torch.cuda.Event()
-            _comm_done.record()
-        torch.cuda.current_stream().wait_event(_comm_done)
-        prev_out = reduce_out_slots[prev_stride_w][prev_slot]
-        dk[:, :, prev_i:prev_i + prev_stride_w].copy_(prev_out[0])
-        dv[:, :, prev_i:prev_i + prev_stride_w].copy_(prev_out[1])
+    rs_manager.drain_to(dk, dv)
 
     return dq, dk, dv
 

--- a/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
+++ b/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
@@ -254,13 +254,23 @@ def llama_flash_attn_backward(
     softcap=0.0,
     alibi_slopes=None,
     deterministic=False,
+    head_first_stride: Optional[int] = None,
+    head_last_stride: Optional[int] = None,
     time_event=None,
 ):
     """
     Llama-style flash attention backward pass.
 
     This function performs the backward pass of attention, distributing the key and value tensors
-    across a process group using all-gather operations.
+    across a process group using all-gather operations and aggregating dk/dv via reduce_scatter.
+
+    Communication is overlapped with compute on both ends:
+    - The first iteration's all_gather can be shrunk via `head_first_stride` (mirroring forward),
+      splitting the first chunk into [head_first_stride, heads_k_stride - head_first_stride].
+    - The last iteration's reduce_scatter can be shrunk via `head_last_stride`, splitting the
+      last chunk into [heads_k_stride - head_last_stride, head_last_stride].
+    - All interior reduce_scatters run async and overlap with the next iteration's
+      flash_attn_backward; only the final, optionally smaller, reduce_scatter is exposed.
 
     Args:
         process_group (dist.ProcessGroup): The distributed process group for communication.
@@ -278,6 +288,10 @@ def llama_flash_attn_backward(
         softcap (float, optional): Softcap for attention scores. Defaults to 0.0.
         alibi_slopes (Optional[torch.Tensor], optional): ALiBi slopes for positional bias. Defaults to None.
         deterministic (bool, optional): Whether to use deterministic algorithms. Defaults to False.
+        head_first_stride (Optional[int], optional): Smaller stride for the first iteration to reduce
+            the size of the un-overlapped initial all_gather. Must be in (0, heads_k_stride). Defaults to None.
+        head_last_stride (Optional[int], optional): Smaller stride for the last iteration to reduce
+            the size of the un-overlapped final reduce_scatter. Must be in (0, heads_k_stride). Defaults to None.
         time_event (Optional[torch.cuda.Event], optional): CUDA event for timing or synchronization. Defaults to None.
 
     Returns:
@@ -290,60 +304,172 @@ def llama_flash_attn_backward(
 
     world_size = dist.get_world_size(process_group)
     rank = dist.get_rank(process_group)
-    
-    kv_buffer = torch.empty(
-        (2, world_size, batch_k, seq_k, heads_k_stride, head_dim),
-        dtype=k.dtype,
-        device=k.device,
-    )
-    kv_buffer_copy = torch.empty_like(kv_buffer)
 
-    # Buffer for gradients coming OUT of Flash Attention.
-    # Shape: [Batch, Seq * WorldSize, Heads, HeadDim]
-    # Must match k.dtype: flash_attn backward requires dk/dv to have the same dtype as k/v.
-    dkv_buffer = torch.empty(
-        (2, batch_k, seq_k * world_size, heads_k_stride, head_dim),
-        dtype=k.dtype,
-        device=k.device,
+    # ---- Build stride pattern (mirrors forward, extended for the tail) ----
+    n_full = nheads_k // heads_k_stride
+    if head_first_stride is not None:
+        assert 0 < head_first_stride < heads_k_stride, (
+            "head_first_stride must be between 0 and heads_k_stride"
+        )
+        first_part = [head_first_stride, heads_k_stride - head_first_stride]
+        n_full -= 1
+    else:
+        first_part = []
+
+    if head_last_stride is not None:
+        assert 0 < head_last_stride < heads_k_stride, (
+            "head_last_stride must be between 0 and heads_k_stride"
+        )
+        last_part = [heads_k_stride - head_last_stride, head_last_stride]
+        n_full -= 1
+    else:
+        last_part = []
+
+    assert n_full >= 0, (
+        f"nheads_k={nheads_k}, heads_k_stride={heads_k_stride} too small to fit "
+        f"both head_first_stride and head_last_stride splits"
     )
 
-    # Contiguous fp32 staging buffer for reduce_scatter input.
-    # Two purposes: (1) reduce_scatter_tensor requires a contiguous tensor, and
-    # dkv_buffer's permuted view is not contiguous; (2) the copy_ upcasts from
-    # k.dtype (bf16/fp16) to fp32 so the cross-rank summation is done in full precision.
-    scatter_input_buffer = torch.empty(
-        (2, world_size, batch_k, seq_k, heads_k_stride, head_dim),
-        dtype=torch.float32,
-        device=k.device,
-    )
+    stride_pattern = first_part + [heads_k_stride] * n_full + last_part
+    n_steps = len(stride_pattern)
+    head_offsets = []
+    cur = 0
+    for s in stride_pattern:
+        head_offsets.append(cur)
+        cur += s
 
-    # Buffer for output of reduce_scatter (fp32, matching scatter_input_buffer)
-    dkv_reduce_output_buffer = torch.empty(
-        (2, batch_k, seq_k, heads_k_stride, head_dim),
-        dtype=torch.float32,
-        device=k.device,
-    )
-    
+    n_first = len(first_part)
+    n_last = len(last_part)
+    middle_start = n_first
+    middle_end = n_steps - n_last  # exclusive
+
+    def is_dedicated_step(step):
+        return step < middle_start or step >= middle_end
+
+    # ---- Buffer allocations ----
+    def kv_shape(width):
+        return (2, world_size, batch_k, seq_k, width, head_dim)
+
+    def dkv_shape(width):
+        return (2, batch_k, seq_k * world_size, width, head_dim)
+
+    def scatter_in_shape(width):
+        return (2, world_size, batch_k, seq_k, width, head_dim)
+
+    def reduce_out_shape(width):
+        return (2, batch_k, seq_k, width, head_dim)
+
+    # KV all_gather destinations: dedicated buffers for first/last small steps,
+    # double-buffered swap pair (kv_buf_main / kv_buf_copy) shared across middle steps.
+    kv_bufs_per_step = [None] * n_steps
+    if n_first >= 1:
+        kv_bufs_per_step[0] = torch.empty(
+            kv_shape(head_first_stride), dtype=k.dtype, device=k.device
+        )
+        kv_bufs_per_step[1] = torch.empty(
+            kv_shape(heads_k_stride - head_first_stride), dtype=k.dtype, device=k.device
+        )
+    if n_last >= 1:
+        kv_bufs_per_step[n_steps - 2] = torch.empty(
+            kv_shape(heads_k_stride - head_last_stride), dtype=k.dtype, device=k.device
+        )
+        kv_bufs_per_step[n_steps - 1] = torch.empty(
+            kv_shape(head_last_stride), dtype=k.dtype, device=k.device
+        )
+
+    if middle_end > middle_start:
+        kv_buf_main = torch.empty(kv_shape(heads_k_stride), dtype=k.dtype, device=k.device)
+        kv_buf_copy = torch.empty(kv_shape(heads_k_stride), dtype=k.dtype, device=k.device)
+    else:
+        kv_buf_main = None
+        kv_buf_copy = None
+
+    # flash_attn_backward writes to a width-specific dkv_buffer (k.dtype, since FA requires it).
+    # One per unique width is enough — flash_attn_backward is sync, so we don't pipeline its writes.
+    unique_widths = set(stride_pattern)
+    dkv_buf_by_width = {
+        w: torch.empty(dkv_shape(w), dtype=k.dtype, device=k.device)
+        for w in unique_widths
+    }
+
+    # Reduce_scatter staging buffers (fp32 for cross-rank precision).
+    # Two slots per width to ping-pong while the previous reduce_scatter is in flight.
+    scatter_in_slots = {
+        w: [
+            torch.empty(scatter_in_shape(w), dtype=torch.float32, device=k.device)
+            for _ in range(2)
+        ]
+        for w in unique_widths
+    }
+    reduce_out_slots = {
+        w: [
+            torch.empty(reduce_out_shape(w), dtype=torch.float32, device=k.device)
+            for _ in range(2)
+        ]
+        for w in unique_widths
+    }
+    next_slot_by_width = {w: 0 for w in unique_widths}
+
     dq = torch.empty_like(q)
     dk = torch.empty_like(k)
     dv = torch.empty_like(v)
 
     comm = Comm(process_group)
 
-    k_0 = k[:, :, :heads_k_stride].contiguous()
-    v_0 = v[:, :, :heads_k_stride].contiguous()
+    # ---- Initial all_gather for step 0 ----
+    first_stride_size = stride_pattern[0]
+    k_0 = k[:, :, :first_stride_size].contiguous()
+    v_0 = v[:, :, :first_stride_size].contiguous()
+    if is_dedicated_step(0):
+        first_dst = kv_bufs_per_step[0]
+    else:
+        # step 0 is the first middle step → gather directly into kv_buf_main (no swap on read)
+        first_dst = kv_buf_main
+    comm.all_gather(first_dst[0], k_0)
+    comm.all_gather(first_dst[1], v_0)
 
-    # Pass the main tensor slices to all_gather
-    comm.all_gather(kv_buffer_copy[0], k_0)
-    comm.all_gather(kv_buffer_copy[1], v_0)
+    # ---- Pipeline state: previous iteration's in-flight reduce_scatter ----
+    prev_handles = None  # (handle_dk, handle_dv, slot, i, stride_w)
 
-    for i in range(0, nheads_k, heads_k_stride):
-        # Must zero out because for Causal, we don't write to the entire sequence length
-        # i.e., use buffer up to (rank+1) instead of full sequence
-        dkv_buffer.zero_()
+    for step, (i, stride_i) in enumerate(zip(head_offsets, stride_pattern)):
+        comm.wait()
 
+        # Select buffer that holds THIS step's gathered K/V.
+        if is_dedicated_step(step):
+            current_kv_buf = kv_bufs_per_step[step]
+        elif step == middle_start:
+            # First middle step: data was gathered directly into kv_buf_main (initial gather
+            # if n_first == 0, else by the prior step's "next" gather targeting kv_buf_main).
+            current_kv_buf = kv_buf_main
+        else:
+            # Subsequent middle step: standard double-buffer swap.
+            kv_buf_main, kv_buf_copy = kv_buf_copy, kv_buf_main
+            current_kv_buf = kv_buf_main
+
+        # Issue the NEXT step's all_gather.
+        if step < n_steps - 1:
+            next_step = step + 1
+            next_stride = stride_pattern[next_step]
+            kv_slice_left = i + stride_i
+            kv_slice_right = kv_slice_left + next_stride
+            send_k = k[:, :, kv_slice_left:kv_slice_right].contiguous()
+            send_v = v[:, :, kv_slice_left:kv_slice_right].contiguous()
+
+            if is_dedicated_step(next_step):
+                next_dst = kv_bufs_per_step[next_step]
+            elif next_step == middle_start:
+                # Gather into kv_buf_main so the first middle step reads it without swapping.
+                next_dst = kv_buf_main
+            else:
+                # Gather into kv_buf_copy; the swap on next iteration will expose it.
+                next_dst = kv_buf_copy
+
+            comm.all_gather(next_dst[0], send_k)
+            comm.all_gather(next_dst[1], send_v)
+
+        # ---- flash_attn_backward ----
         q_slice = slice(
-            i * nheads // nheads_k, (i + heads_k_stride) * nheads // nheads_k
+            i * nheads // nheads_k, (i + stride_i) * nheads // nheads_k
         )
         q_i = q[:, :, q_slice]
         dout_i = dout[:, :, q_slice]
@@ -354,91 +480,88 @@ def llama_flash_attn_backward(
         else:
             lse_i = softmax_lse[q_slice]
 
-        comm.wait()
-        # Swap the main storage tensors
-        kv_buffer, kv_buffer_copy = kv_buffer_copy, kv_buffer
-
-        if i < nheads_k - heads_k_stride:
-            # all_gather the next kv slice
-            kv_slice_left = i + heads_k_stride
-            kv_slice_right = kv_slice_left + heads_k_stride
-            send_k = k[:, :, kv_slice_left:kv_slice_right].contiguous()
-            send_v = v[:, :, kv_slice_left:kv_slice_right].contiguous()
-            # Pass the main tensor slices for the next round
-            comm.all_gather(kv_buffer_copy[0], send_k)
-            comm.all_gather(kv_buffer_copy[1], send_v)
-
-        # kv_buffer[0] has shape (world_size, batch_k, seq_k, heads_k_stride, head_dim)
-        # We want k_i to be (batch_k, seq_k * world_size, heads_k_stride, head_dim)
         if causal:
-            k_i = kv_buffer[0][:(rank + 1)]
-            v_i = kv_buffer[1][:(rank + 1)]
+            k_i = current_kv_buf[0][:(rank + 1)]
+            v_i = current_kv_buf[1][:(rank + 1)]
             k_i = rearrange(k_i, 'w b s hs dh -> b (w s) hs dh').contiguous()
             v_i = rearrange(v_i, 'w b s hs dh -> b (w s) hs dh').contiguous()
         else:
-            k_i = rearrange(kv_buffer[0], 'w b s hs dh -> b (w s) hs dh').contiguous()
-            v_i = rearrange(kv_buffer[1], 'w b s hs dh -> b (w s) hs dh').contiguous()
+            k_i = rearrange(current_kv_buf[0], 'w b s hs dh -> b (w s) hs dh').contiguous()
+            v_i = rearrange(current_kv_buf[1], 'w b s hs dh -> b (w s) hs dh').contiguous()
 
+        dkv_buf = dkv_buf_by_width[stride_i]
+        # Zero so the unused (rank+1, world_size) slice contributes 0 to the cross-rank sum.
+        dkv_buf.zero_()
         if causal:
-            # dk must have the same shape as k
-            dk_i = dkv_buffer[0][:, :k_i.shape[1]]
-            dv_i = dkv_buffer[1][:, :k_i.shape[1]]
+            dk_i = dkv_buf[0][:, :k_i.shape[1]]
+            dv_i = dkv_buf[1][:, :k_i.shape[1]]
         else:
-            dk_i = dkv_buffer[0]
-            dv_i = dkv_buffer[1]
+            dk_i = dkv_buf[0]
+            dv_i = dkv_buf[1]
 
-        # params = get_default_args(_flash_attn_varlen_backward).copy()
         params = {
-                "dout": dout_i,
-                "q": q_i,
-                "k": k_i,
-                "v": v_i,
-                "out": out_i,
-                "softmax_lse": lse_i,
-                "dq": dq_i,
-                "dk": dk_i,
-                "dv": dv_i,
-                "dropout_p": dropout_p,
-                "softmax_scale": softmax_scale,
-                "causal": causal,
-                "window_size_left": window_size[0],
-                "window_size_right": window_size[1],
-                "softcap": softcap,
-                "alibi_slopes": alibi_slopes,
-                "deterministic": deterministic,
+            "dout": dout_i,
+            "q": q_i,
+            "k": k_i,
+            "v": v_i,
+            "out": out_i,
+            "softmax_lse": lse_i,
+            "dq": dq_i,
+            "dk": dk_i,
+            "dv": dv_i,
+            "dropout_p": dropout_p,
+            "softmax_scale": softmax_scale,
+            "causal": causal,
+            "window_size_left": window_size[0],
+            "window_size_right": window_size[1],
+            "softcap": softcap,
+            "alibi_slopes": alibi_slopes,
+            "deterministic": deterministic,
         }
         _wrapped_flash_attn_backward(**params)
-
-        # We do not need k_i, v_i, or the slices anymore.
         del k_i, v_i, q_i, dout_i, out_i
 
-        # Target for reduce_scatter is always our FP32 buffer
-        dk_i = dkv_reduce_output_buffer[0]
-        dv_i = dkv_reduce_output_buffer[1]
+        # ---- Drain the previous iteration's async reduce_scatter ----
+        # Done AFTER flash_attn_backward so they overlap on the GPU.
+        if prev_handles is not None:
+            prev_h_dk, prev_h_dv, prev_slot, prev_i, prev_stride_w = prev_handles
+            prev_h_dk.wait()
+            prev_h_dv.wait()
+            prev_out = reduce_out_slots[prev_stride_w][prev_slot]
+            dk[:, :, prev_i:prev_i + prev_stride_w].copy_(prev_out[0])
+            dv[:, :, prev_i:prev_i + prev_stride_w].copy_(prev_out[1])
 
-        # Rearrange dkv_buffer so the first dimension represents the World Rank.
-        # dkv_buffer is [2, B, W*S, H, D]. We need to transform to [2, W, B, S, H, D]
-        # 1. View: Split W*S -> W, S.  Shape: [2, B, W, S, H, D]
-        grad_view = dkv_buffer.view(2, batch_k, world_size, seq_k, heads_k_stride, head_dim)
-        # 2. Permute: Swap B and W. Shape: [2, W, B, S, H, D]
+        # ---- Stage and issue THIS iteration's async reduce_scatter ----
+        # Permute (2, B, W*S, H, D) -> (2, W, B, S, H, D) and upcast to fp32 via copy_.
+        grad_view = dkv_buf.view(2, batch_k, world_size, seq_k, stride_i, head_dim)
         grad_permuted = grad_view.permute(0, 2, 1, 3, 4, 5)
-        # if scatter_input_buffer in fp32, precision gets promoted
-        scatter_input_buffer.copy_(grad_permuted)
 
-        # dist.reduce_scatter_tensor concat, gather, reduce on dim=0
-        dist.reduce_scatter_tensor(dk_i, scatter_input_buffer[0], group=process_group)
-        dist.reduce_scatter_tensor(dv_i, scatter_input_buffer[1], group=process_group)
+        slot = next_slot_by_width[stride_i]
+        next_slot_by_width[stride_i] = 1 - slot
 
-        # Final copy back to main bf16/fp16 tensor
-        if heads_k_stride != nheads_k:
-            dk[:, :, i : i + heads_k_stride].copy_(dk_i)
-            dv[:, :, i : i + heads_k_stride].copy_(dv_i)
-        else:
-            dk.copy_(dk_i)
-            dv.copy_(dv_i)
+        scatter_in = scatter_in_slots[stride_i][slot]
+        reduce_out = reduce_out_slots[stride_i][slot]
+        scatter_in.copy_(grad_permuted)
 
-        if i == 0 and time_event is not None:
+        h_dk = dist.reduce_scatter_tensor(
+            reduce_out[0], scatter_in[0], group=process_group, async_op=True
+        )
+        h_dv = dist.reduce_scatter_tensor(
+            reduce_out[1], scatter_in[1], group=process_group, async_op=True
+        )
+        prev_handles = (h_dk, h_dv, slot, i, stride_i)
+
+        if step == 0 and time_event is not None:
             time_event.record()
+
+    # ---- Drain the final reduce_scatter ----
+    if prev_handles is not None:
+        prev_h_dk, prev_h_dv, prev_slot, prev_i, prev_stride_w = prev_handles
+        prev_h_dk.wait()
+        prev_h_dv.wait()
+        prev_out = reduce_out_slots[prev_stride_w][prev_slot]
+        dk[:, :, prev_i:prev_i + prev_stride_w].copy_(prev_out[0])
+        dv[:, :, prev_i:prev_i + prev_stride_w].copy_(prev_out[1])
 
     return dq, dk, dv
 
@@ -591,6 +714,7 @@ class LlamaFlashAttnFunc(torch.autograd.Function):
         heads_k_stride: int,
         head_first_stride: Optional[int],
         pack_first_stride: bool,
+        head_last_stride: Optional[int],
         dropout_p: float,
         softmax_scale: Optional[float],
         causal: bool,
@@ -661,6 +785,8 @@ class LlamaFlashAttnFunc(torch.autograd.Function):
         ctx.group = group
         ctx.bwd_event_sync = bwd_event_sync
         ctx.heads_k_stride = heads_k_stride
+        ctx.head_first_stride = head_first_stride
+        ctx.head_last_stride = head_last_stride
         return out if not return_softmax else (out, softmax_lse, None)
 
     @staticmethod
@@ -684,12 +810,14 @@ class LlamaFlashAttnFunc(torch.autograd.Function):
             window_size=ctx.window_size,
             alibi_slopes=ctx.alibi_slopes,
             deterministic=ctx.deterministic,
+            head_first_stride=ctx.head_first_stride,
+            head_last_stride=ctx.head_last_stride,
             time_event=time_event,
         )
         if ctx.bwd_event_sync:
             time_event.synchronize()
-        # forward takes 15 args excluding ctx. return 3 grad + 12 None
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None
+        # forward takes 16 args excluding ctx. return 3 grad + 13 None
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None
 
 
 def llama_fwd_ring_bwd_flash_attn_func(
@@ -772,6 +900,7 @@ def llama_flash_attn_func(
     heads_k_stride: int = 1,
     head_first_stride: Optional[int] = None,
     pack_first_stride: bool = True,
+    head_last_stride: Optional[int] = None,
     dropout_p: float = 0.0,
     softmax_scale: Optional[float] = None,
     causal: bool = False,
@@ -790,6 +919,7 @@ def llama_flash_attn_func(
         heads_k_stride,
         head_first_stride,
         pack_first_stride,
+        head_last_stride,
         dropout_p,
         softmax_scale,
         causal,
@@ -900,6 +1030,7 @@ class ConditionalLlamaFlashAttnFunc(torch.autograd.Function):
         heads_k_stride: int,
         head_first_stride: Optional[int],
         pack_first_stride: bool,
+        head_last_stride: Optional[int],
         dropout_p: float,
         softmax_scale: Optional[float],
         causal: bool,
@@ -997,6 +1128,8 @@ class ConditionalLlamaFlashAttnFunc(torch.autograd.Function):
         ctx.deterministic = deterministic
         ctx.group = group
         ctx.heads_k_stride = heads_k_stride
+        ctx.head_first_stride = head_first_stride
+        ctx.head_last_stride = head_last_stride
         return out if not return_softmax else (out, softmax_lse, None)
 
     @staticmethod
@@ -1049,12 +1182,14 @@ class ConditionalLlamaFlashAttnFunc(torch.autograd.Function):
                 window_size=ctx.window_size,
                 alibi_slopes=ctx.alibi_slopes,
                 deterministic=ctx.deterministic,
+                head_first_stride=ctx.head_first_stride,
+                head_last_stride=ctx.head_last_stride,
                 time_event=time_event,
             )
         if ctx.bwd_event_sync:
             time_event.synchronize()
-        # forward takes 15 args excluding ctx. return 3 grad + 12 None
-        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None
+        # forward takes 16 args excluding ctx. return 3 grad + 13 None
+        return dq, dk, dv, None, None, None, None, None, None, None, None, None, None, None, None, None
 
 
 class ConditionalLlamaRingFlashAttnFunc(torch.autograd.Function):
@@ -1250,6 +1385,7 @@ def cond_llama_flash_attn_func(
     heads_k_stride: int = 1,
     head_first_stride: Optional[int] = None,
     pack_first_stride: bool = True,
+    head_last_stride: Optional[int] = None,
     dropout_p: float = 0.0,
     softmax_scale: Optional[float] = None,
     causal: bool = False,
@@ -1272,6 +1408,7 @@ def cond_llama_flash_attn_func(
         heads_k_stride,
         head_first_stride,
         pack_first_stride,
+        head_last_stride,
         dropout_p,
         softmax_scale,
         causal,

--- a/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
+++ b/ring_flash_attn/llama_fwd_ring_bwd_flash_attn.py
@@ -553,18 +553,16 @@ def llama_flash_attn_backward(
         reduce_out = reduce_out_slots[stride_i][slot]
         scatter_in.copy_(grad_permuted)
 
-        # Signal to comm_stream that scatter_in is ready on the compute stream.
-        _compute_ready = torch.cuda.Event()
-        _compute_ready.record()
-        comm_stream.wait_event(_compute_ready)
-
-        with torch.cuda.stream(comm_stream):
-            h_dk = dist.reduce_scatter_tensor(
-                reduce_out[0], scatter_in[0], group=process_group, async_op=True
-            )
-            h_dv = dist.reduce_scatter_tensor(
-                reduce_out[1], scatter_in[1], group=process_group, async_op=True
-            )
+        # Issue from compute stream so NCCL automatically captures the scatter_in.copy_()
+        # dependency. NCCL runs on its own internal stream regardless of the calling stream;
+        # Work.wait() is called from comm_stream (see drain below) so compute_stream is
+        # never blocked by NCCL completion.
+        h_dk = dist.reduce_scatter_tensor(
+            reduce_out[0], scatter_in[0], group=process_group, async_op=True
+        )
+        h_dv = dist.reduce_scatter_tensor(
+            reduce_out[1], scatter_in[1], group=process_group, async_op=True
+        )
         prev_handles = (h_dk, h_dv, slot, i, stride_i)
 
         if step == 0 and time_event is not None:

--- a/ring_flash_attn/utils.py
+++ b/ring_flash_attn/utils.py
@@ -171,10 +171,27 @@ class AllGatherComm:
 class ReduceScatterHandleManager:
     def __init__(self, group=None, device=None, use_coalesced: Optional[bool] = None):
         if group is None:
-            group = dist.distributed_c10d._get_default_group()
+            group = dist.group.WORLD
+        if group is None:
+            raise RuntimeError(
+                "ReduceScatterHandleManager requires an initialized process group"
+            )
         self.group = group
         self._world_size = dist.get_world_size(group)
-        self._group_name = group.group_name
+
+        group_name = getattr(group, "group_name", None)
+        if callable(group_name):
+            group_name = group_name()
+        if group_name is None:
+            group_name = getattr(group, "name", None)
+            if callable(group_name):
+                group_name = group_name()
+        if group_name is None:
+            raise RuntimeError(
+                "Could not determine a process-group name for c10d functional collectives"
+            )
+        self._group_name = group_name
+
         self._supports_coalesced = hasattr(
             torch.ops._c10d_functional, "reduce_scatter_tensor_coalesced"
         )

--- a/ring_flash_attn/utils.py
+++ b/ring_flash_attn/utils.py
@@ -173,7 +173,6 @@ class ReduceScatterHandleManager:
         self,
         group=None,
         group_name: Optional[str] = None,
-        device=None,
         use_coalesced: Optional[bool] = None,
     ):
         # Require torch.distributed to be initialized unless caller supplies

--- a/ring_flash_attn/utils.py
+++ b/ring_flash_attn/utils.py
@@ -166,3 +166,59 @@ class AllGatherComm:
         for handle in self.handles:
             handle.wait()
         self.handles = []
+
+
+class ReduceScatterHandleManager:
+    def __init__(self, group=None, device=None, use_coalesced: Optional[bool] = None):
+        if group is None:
+            group = dist.distributed_c10d._get_default_group()
+        self.group = group
+        self._world_size = dist.get_world_size(group)
+        self._group_name = group.group_name
+        self._supports_coalesced = hasattr(
+            torch.ops._c10d_functional, "reduce_scatter_tensor_coalesced"
+        )
+        if use_coalesced is None:
+            self._use_coalesced = self._supports_coalesced
+        else:
+            self._use_coalesced = use_coalesced and self._supports_coalesced
+        self.pending = None
+
+    def issue(
+        self,
+        scatter_in_dk: torch.Tensor,
+        scatter_in_dv: torch.Tensor,
+        head_offset: int,
+        width: int,
+    ):
+        if self.pending is not None:
+            raise RuntimeError("issue called before draining previous reduce_scatter")
+
+        if self._use_coalesced:
+            out_dk, out_dv = torch.ops._c10d_functional.reduce_scatter_tensor_coalesced(
+                [scatter_in_dk, scatter_in_dv],
+                "sum",
+                self._world_size,
+                self._group_name,
+            )
+        else:
+            out_dk = torch.ops._c10d_functional.reduce_scatter_tensor(
+                scatter_in_dk, "sum", self._world_size, self._group_name
+            )
+            out_dv = torch.ops._c10d_functional.reduce_scatter_tensor(
+                scatter_in_dv, "sum", self._world_size, self._group_name
+            )
+
+        self.pending = (out_dk, out_dv, head_offset, width)
+
+    def drain_to(self, dk: torch.Tensor, dv: torch.Tensor):
+        if self.pending is None:
+            return
+        out_dk, out_dv, head_offset, width = self.pending
+        out_dk = torch.ops._c10d_functional.wait_tensor(out_dk)
+        out_dv = torch.ops._c10d_functional.wait_tensor(out_dv)
+        dk_slice = dk[:, :, head_offset:head_offset + width]
+        dv_slice = dv[:, :, head_offset:head_offset + width]
+        dk_slice.copy_(out_dk.reshape(dk_slice.shape))
+        dv_slice.copy_(out_dv.reshape(dv_slice.shape))
+        self.pending = None

--- a/ring_flash_attn/utils.py
+++ b/ring_flash_attn/utils.py
@@ -169,27 +169,72 @@ class AllGatherComm:
 
 
 class ReduceScatterHandleManager:
-    def __init__(self, group=None, device=None, use_coalesced: Optional[bool] = None):
-        if group is None:
-            group = dist.group.WORLD
-        if group is None:
-            raise RuntimeError(
-                "ReduceScatterHandleManager requires an initialized process group"
-            )
-        self.group = group
-        self._world_size = dist.get_world_size(group)
+    def __init__(
+        self,
+        group=None,
+        group_name: Optional[str] = None,
+        device=None,
+        use_coalesced: Optional[bool] = None,
+    ):
+        # Require torch.distributed to be initialized unless caller supplies
+        # either an explicit group or an explicit group_name.
+        if not getattr(dist, "is_initialized", lambda: False)():
+            if group is None and group_name is None:
+                raise RuntimeError(
+                    "torch.distributed is not initialized; initialize it or pass `group` or `group_name`"
+                )
 
-        group_name = getattr(group, "group_name", None)
-        if callable(group_name):
-            group_name = group_name()
+        if group is None:
+            # prefer the default WORLD group when available
+            group = getattr(dist, "group", None)
+            if group is not None:
+                try:
+                    group = dist.group.WORLD
+                except Exception:
+                    group = None
+
+        self.group = group
+
+        # Resolve world size if possible (give a clearer error if it fails)
+        try:
+            if self.group is not None:
+                self._world_size = dist.get_world_size(self.group)
+            else:
+                # If no ProcessGroup object was supplied, require caller to have
+                # provided a group_name and rely on functional APIs to accept it.
+                raise RuntimeError("no process group available")
+        except Exception as e:
+            raise RuntimeError(
+                "failed to determine world size for provided group; pass a valid ProcessGroup or ensure torch.distributed is initialized"
+            ) from e
+
+        # Allow explicit override of the c10d functional group name to avoid
+        # fragile introspection of ProcessGroup internals.
         if group_name is None:
-            group_name = getattr(group, "name", None)
+            group_name = getattr(self.group, "group_name", None)
             if callable(group_name):
-                group_name = group_name()
+                try:
+                    group_name = group_name()
+                except TypeError:
+                    group_name = None
+
+        if group_name is None:
+            group_name = getattr(self.group, "name", None)
+            if callable(group_name):
+                try:
+                    group_name = group_name()
+                except TypeError:
+                    group_name = None
+
+        if group_name is None:
+            # some implementations expose a private attribute
+            group_name = getattr(self.group, "_group_name", None)
+
         if group_name is None:
             raise RuntimeError(
-                "Could not determine a process-group name for c10d functional collectives"
+                "Could not determine a process-group name for c10d functional collectives; pass explicit `group_name`"
             )
+
         self._group_name = group_name
 
         self._supports_coalesced = hasattr(
@@ -199,6 +244,7 @@ class ReduceScatterHandleManager:
             self._use_coalesced = self._supports_coalesced
         else:
             self._use_coalesced = use_coalesced and self._supports_coalesced
+
         self.pending = None
 
     def issue(

--- a/test/test_llama_bwd_stride_flags.py
+++ b/test/test_llama_bwd_stride_flags.py
@@ -1,0 +1,128 @@
+import unittest
+import torch
+from unittest.mock import patch
+
+from ring_flash_attn import llama_fwd_ring_bwd_flash_attn as mod
+
+
+class DummyComm:
+    def __init__(self, pg):
+        self.pg = pg
+
+    def all_gather(self, dst, src):
+        # place src at index 0 (simulate rank 0 contribution)
+        try:
+            dst.zero_()
+            dst[0].copy_(src)
+        except Exception:
+            # best-effort: if shapes mismatch, try a simple copy
+            dst.copy_(src)
+
+    def wait(self):
+        return
+
+
+class DummyRSManager:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def issue(self, *args, **kwargs):
+        return
+
+    def drain_to(self, dk, dv):
+        # no-op: assume dk/dv already set by backward stub
+        return
+
+
+def fake_backward(**params):
+    # Fill any floating-point tensor argument with a recognizable value so tests
+    # can detect that the backward stub ran. Use different values for dq/dk/dv
+    # when present.
+    for k, v in params.items():
+        if isinstance(v, torch.Tensor) and v.is_floating_point():
+            if k == "dq":
+                v.fill_(3.0)
+            elif k == "dk":
+                v.fill_(4.0)
+            elif k == "dv":
+                v.fill_(5.0)
+            else:
+                v.fill_(7.0)
+
+
+class TestBwdStrideFlags(unittest.TestCase):
+    def setUp(self):
+        # small tensors
+        self.batch = 1
+        self.seq = 4
+        self.nheads = 4
+        self.nheads_k = 4
+        self.head_dim = 8
+
+    @patch("ring_flash_attn.llama_fwd_ring_bwd_flash_attn.Comm", DummyComm)
+    @patch("ring_flash_attn.llama_fwd_ring_bwd_flash_attn.ReduceScatterHandleManager", DummyRSManager)
+    @patch("ring_flash_attn.llama_fwd_ring_bwd_flash_attn._wrapped_flash_attn_backward", fake_backward)
+    @patch("ring_flash_attn.llama_fwd_ring_bwd_flash_attn.dist.get_world_size", return_value=1)
+    @patch("ring_flash_attn.llama_fwd_ring_bwd_flash_attn.dist.get_rank", return_value=0)
+    def test_valid_first_and_last_stride(self, mock_rank, mock_wsize):
+        q = torch.zeros((self.batch, self.seq, self.nheads, self.head_dim))
+        k = torch.zeros((self.batch, self.seq, self.nheads_k, self.head_dim))
+        v = torch.zeros_like(k)
+        out = torch.zeros_like(q)
+        softmax_lse = torch.zeros((self.nheads, self.seq))
+        dout = torch.zeros_like(q)
+
+        dq, dk, dv = mod.llama_flash_attn_backward(
+            process_group=None,
+            dout=dout,
+            q=q,
+            k=k,
+            v=v,
+            out=out,
+            softmax_lse=softmax_lse,
+            heads_k_stride=2,
+            softmax_scale=1.0,
+            dropout_p=0,
+            causal=False,
+            bwd_head_first_stride=1,
+            bwd_head_last_stride=1,
+        )
+
+        # shapes preserved
+        self.assertEqual(dq.shape, q.shape)
+        self.assertEqual(dk.shape, k.shape)
+        self.assertEqual(dv.shape, v.shape)
+
+        # our fake backward wrote to dq; ensure shapes for dk/dv preserved
+        self.assertTrue(torch.any(dq == 3.0))
+        self.assertEqual(dk.shape, k.shape)
+        self.assertEqual(dv.shape, v.shape)
+
+    @patch("ring_flash_attn.llama_fwd_ring_bwd_flash_attn.dist.get_world_size", return_value=1)
+    @patch("ring_flash_attn.llama_fwd_ring_bwd_flash_attn.dist.get_rank", return_value=0)
+    def test_invalid_splits_raise(self, mock_rank, mock_wsize):
+        q = torch.zeros((1, 2, 2, 4))
+        k = torch.zeros((1, 2, 2, 4))
+        v = torch.zeros_like(k)
+        out = torch.zeros_like(q)
+        softmax_lse = torch.zeros((2, 2))
+        dout = torch.zeros_like(q)
+
+        # bwd_head_first_stride equals heads_k_stride → should assert
+        with self.assertRaises(AssertionError):
+            mod.llama_flash_attn_backward(
+                process_group=None,
+                dout=dout,
+                q=q,
+                k=k,
+                v=v,
+                out=out,
+                softmax_lse=softmax_lse,
+                heads_k_stride=2,
+                softmax_scale=1.0,
+                bwd_head_first_stride=2,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_reduce_scatter_handle_manager.py
+++ b/test/test_reduce_scatter_handle_manager.py
@@ -1,0 +1,33 @@
+import unittest
+from ring_flash_attn.utils import ReduceScatterHandleManager
+from unittest.mock import patch
+
+
+class TestReduceScatterHandleManager(unittest.TestCase):
+    def test_init_with_explicit_group_name(self):
+        with patch("ring_flash_attn.utils.dist.is_initialized", return_value=True), \
+            patch("ring_flash_attn.utils.dist.get_world_size", return_value=4):
+            mgr = ReduceScatterHandleManager(group=object(), group_name="mygrp")
+            self.assertEqual(mgr._group_name, "mygrp")
+            self.assertEqual(mgr._world_size, 4)
+
+    def test_init_autodetect_group_name_from_group_name_attr(self):
+        class G:
+            def group_name(self):
+                return "grp"
+
+        g = G()
+        with patch("ring_flash_attn.utils.dist.is_initialized", return_value=True), \
+            patch("ring_flash_attn.utils.dist.get_world_size", return_value=2):
+            mgr = ReduceScatterHandleManager(group=g)
+            self.assertEqual(mgr._group_name, "grp")
+            self.assertEqual(mgr._world_size, 2)
+
+    def test_init_raises_if_not_initialized_and_no_group_or_name(self):
+        with patch("ring_flash_attn.utils.dist.is_initialized", return_value=False):
+            with self.assertRaises(RuntimeError):
+                ReduceScatterHandleManager(group=None, group_name=None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This pull request introduces advanced optimizations and configurability for the backward pass in the `llama_fwd_ring_bwd_flash_attn.py` module, focusing on improving the efficiency and flexibility of distributed attention computation. The main changes add support for custom stride patterns in the backward pass, overlap communication and computation more effectively, and refactor buffer management for better performance and clarity. Reduce scatter with float tensors.

Key improvements and new features:

**Backward Pass Optimizations:**

- KEY: float32 buffers for reduce scatter for better precision
- Added support for `bwd_head_first_stride` and `bwd_head_last_stride` arguments to allow the first and last backward communication steps to use smaller strides, reducing the size of un-overlapped all-gather and reduce-scatter operations and improving pipeline efficiency. [[1]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R261-R277) [[2]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R295-R298) [[3]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R684-R685) [[4]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R756-R757) [[5]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R781-R788) [[6]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R871-R872) [[7]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R891-R892) [[8]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R1003-R1004) [[9]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R1102-R1103)

- Refactored the stride pattern logic in the backward pass to support arbitrary stride splits, with assertions and logic to ensure correctness and buffer allocation for each step. This enables flexible partitioning of attention heads across communication steps.

**Communication and Buffer Management:**

- Introduced a `ReduceScatterHandleManager` to manage asynchronous reduce-scatter operations, allowing communication to be overlapped with computation for all interior steps and draining the handles at the correct cadence. [[1]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2L7-R11) [[2]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2L294-R463) [[3]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2L408-R532)

- Refactored buffer allocation: now uses per-stride-width buffers and double-buffering for the main communication steps, with dedicated buffers for the first and last (potentially smaller) steps. This change improves memory efficiency and pipeline overlap. [[1]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2L294-R463) [[2]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2L354-L387)

**API and Documentation Updates:**

- Updated the function signatures and context handling throughout the forward and backward functions to propagate the new stride arguments, ensuring they are available during autograd. [[1]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R684-R685) [[2]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R756-R757) [[3]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R781-R788) [[4]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R871-R872) [[5]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R891-R892) [[6]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R1003-R1004) [[7]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R1102-R1103)

- Expanded the docstrings and comments to document the new stride options, pipeline mechanics, and buffer management, making the codebase easier to understand and extend. [[1]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R261-R277) [[2]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2R295-R298) [[3]](diffhunk://#diff-fb7aca85307b2ad5ae4fdd8d009464f6e6c75ceae419d866f7851655034398d2L294-R463)

**Project Documentation:**

- Added a new `CLAUDE.md` file with high-level project guidance, installation and test commands, architectural overview, and design constraints for contributors and users.