### PR TITLE
Fix deprecated import for flash attention utility in hf_adapter.py

### DIFF
--- a/ring_flash_attn/adapters/hf_adapter.py
+++ b/ring_flash_attn/adapters/hf_adapter.py
@@ -7,13 +7,13 @@ import torch.distributed as dist
 import transformers
 import transformers.modeling_flash_attention_utils
 try:
+    from transformers.utils import is_flash_attn_greater_or_equal
+    is_flash_attn_greater_or_equal_2_10 = is_flash_attn_greater_or_equal("2.1.0")
+except ImportError:
+    # legacy support
     from transformers.modeling_flash_attention_utils import (
         is_flash_attn_greater_or_equal_2_10,
     )
-except ImportError:
-    # transformers <= 4.53.x
-    from transformers.utils import is_flash_attn_greater_or_equal
-    is_flash_attn_greater_or_equal_2_10 = is_flash_attn_greater_or_equal("2.1.0")
 
 from ..llama3_flash_attn_varlen import (
     llama3_flash_attn_varlen_func,

--- a/ring_flash_attn/adapters/hf_adapter.py
+++ b/ring_flash_attn/adapters/hf_adapter.py
@@ -12,9 +12,8 @@ try:
     )
 except ImportError:
     # transformers <= 4.53.x
-    from transformers.modeling_flash_attention_utils import (
-        is_flash_attn_greater_or_equal_2_10,
-    )
+    from transformers.utils import is_flash_attn_greater_or_equal
+    is_flash_attn_greater_or_equal_2_10 = is_flash_attn_greater_or_equal("2.1.0")
 
 from ..llama3_flash_attn_varlen import (
     llama3_flash_attn_varlen_func,


### PR DESCRIPTION
This pull request updates the way the `is_flash_attn_greater_or_equal_2_10` check is imported and defined in `hf_adapter.py` to improve compatibility with different versions of the `transformers` library.

Dependency compatibility:

* Replaces the import of `is_flash_attn_greater_or_equal_2_10` from `transformers.modeling_flash_attention_utils` with a version-agnostic approach: imports `is_flash_attn_greater_or_equal` from `transformers.utils` and defines `is_flash_attn_greater_or_equal_2_10` by calling it with `"2.1.0"`.